### PR TITLE
Configure Prod environment for deployment to Linode cluster

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -2,5 +2,13 @@
   "semi": false,
   "tabWidth": 2,
   "trailingComma": "none",
-  "arrowParens": "avoid"
+  "arrowParens": "avoid",
+  "overrides": [
+    {
+      "files": ["*.yaml", "*.yml"],
+      "options": {
+        "bracketSpacing": false
+      }
+    }
+  ]
 }

--- a/functions/.env.digital-testimony-prod
+++ b/functions/.env.digital-testimony-prod
@@ -1,1 +1,1 @@
-TYPESENSE_API_URL=https://maple-prod2.alexjball.com/search
+TYPESENSE_API_URL=https://api.mapletestimony.org/search

--- a/functions/.env.digital-testimony-prod
+++ b/functions/.env.digital-testimony-prod
@@ -1,1 +1,1 @@
-TYPESENSE_API_URL=https://maple-prod.alexjball.com/search
+TYPESENSE_API_URL=https://maple-prod2.alexjball.com/search

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -20,7 +20,7 @@ export {
   startMemberBatches
 } from "./members"
 export { createProfile } from "./profile"
-export { checkSearchIndexVersion } from "./search"
+export { checkSearchIndexVersion, searchHealthCheck } from "./search"
 export {
   deleteTestimony,
   publishTestimony,

--- a/functions/src/search/client.ts
+++ b/functions/src/search/client.ts
@@ -1,9 +1,18 @@
 import { Client } from "typesense"
 
-export const createClient = (
+type Config = Omit<
+  ConstructorParameters<typeof Client>[0],
+  "apiKey" | "nodes"
+> & {
+  apiUrl?: string
+  apiKey?: string
+}
+
+export const createClient = ({
   apiUrl = process.env.TYPESENSE_API_URL!,
-  apiKey = process.env.TYPESENSE_API_KEY!
-) => {
+  apiKey = process.env.TYPESENSE_API_KEY!,
+  ...config
+}: Config = {}) => {
   const url = new URL(apiUrl)
   const protocol = url.protocol.startsWith("https") ? "https" : "http"
   const port = url.port ? Number(url.port) : protocol === "https" ? 443 : 80
@@ -17,6 +26,7 @@ export const createClient = (
         port,
         path: url.pathname
       }
-    ]
+    ],
+    ...config
   })
 }

--- a/functions/src/search/index.ts
+++ b/functions/src/search/index.ts
@@ -1,3 +1,4 @@
 export * from "./checkSearchIndexVersion"
 export type { CollectionConfig, Schema } from "./config"
 export * from "./createSearchIndexer"
+export * from "./searchHealthCheck"

--- a/functions/src/search/searchHealthCheck.ts
+++ b/functions/src/search/searchHealthCheck.ts
@@ -1,0 +1,30 @@
+import { runWith } from "firebase-functions"
+import { createClient } from "./client"
+
+const connectionTimeoutSeconds = 5,
+  numRetries = 2,
+  functionTimeoutSeconds = 30
+
+/** Checks that the search backend is working. If this fails it will trigger an
+ * alert. */
+export const searchHealthCheck = runWith({
+  secrets: ["TYPESENSE_API_KEY"],
+  timeoutSeconds: functionTimeoutSeconds,
+  memory: "128MB"
+})
+  .pubsub.schedule("every 30 minutes")
+  .retryConfig({
+    // Retry using the client
+    retryCount: 0
+  })
+  .onRun(async () => {
+    const client = createClient({
+      connectionTimeoutSeconds,
+      numRetries
+    })
+    const res = await client.health.retrieve()
+    if (!res.ok)
+      throw Error(
+        `Search backend responded with failure: ${JSON.stringify(res)}`
+      )
+  })

--- a/infra/app/templates/typesense-pvc.yml
+++ b/infra/app/templates/typesense-pvc.yml
@@ -7,5 +7,5 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 1Gi
-  storageClassName: "{{ .Values.storageClassName }}"
+      storage: {{.Values.storageSize | default "1Gi"}}
+  storageClassName: {{.Values.storageClassName}}

--- a/infra/prod/dist.yml
+++ b/infra/prod/dist.yml
@@ -2384,8 +2384,8 @@ spec:
   - ReadWriteOnce
   resources:
     requests:
-      storage: 1Gi
-  storageClassName: standard-rwo
+      storage: 10Gi
+  storageClassName: linode-block-storage-retain
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -2579,7 +2579,7 @@ spec:
   - websecure
   routes:
   - kind: Rule
-    match: Host(`maple-prod.alexjball.com`) && PathPrefix(`/search`)
+    match: Host(`maple-prod2.alexjball.com`) && PathPrefix(`/search`)
     middlewares:
     - name: typesense-strip-prefix
     services:

--- a/infra/prod/dist.yml
+++ b/infra/prod/dist.yml
@@ -2579,7 +2579,7 @@ spec:
   - websecure
   routes:
   - kind: Rule
-    match: Host(`maple-prod2.alexjball.com`) && PathPrefix(`/search`)
+    match: (Host(`api.mapletestimony.org`) || Host(`maple-prod2.alexjball.com`)) && PathPrefix(`/search`)
     middlewares:
     - name: typesense-strip-prefix
     services:

--- a/infra/prod/kustomization.yaml
+++ b/infra/prod/kustomization.yaml
@@ -10,7 +10,7 @@ helmCharts:
     includeCRDs: true
     releaseName: prod
     valuesInline:
-      apiDomain: maple-prod2.alexjball.com
+      apiDomain: api.mapletestimony.org
       storageSize: 10Gi
       storageClassName: linode-block-storage-retain
       secretName: typesense

--- a/infra/prod/kustomization.yaml
+++ b/infra/prod/kustomization.yaml
@@ -10,8 +10,9 @@ helmCharts:
     includeCRDs: true
     releaseName: prod
     valuesInline:
-      apiDomain: maple-prod.alexjball.com
-      storageClassName: standard-rwo
+      apiDomain: maple-prod2.alexjball.com
+      storageSize: 10Gi
+      storageClassName: linode-block-storage-retain
       secretName: typesense
 
 resources:

--- a/scripts/typesense-admin.ts
+++ b/scripts/typesense-admin.ts
@@ -12,7 +12,7 @@ declare global {
 const envs: Record<string, { url: string; key?: string; alias?: string }> = {
   local: { url: "http://localhost:8108", key: "test-api-key" },
   dev: { url: "https://maple.aballslab.com/search", alias: "default" },
-  prod: { url: "https://maple-prod.alexjball.com/search", alias: "prod" }
+  prod: { url: "https://api.mapletestimony.org/search", alias: "prod" }
 }
 
 type Args = { url?: string; key?: string; env?: string }

--- a/scripts/typesense-admin.ts
+++ b/scripts/typesense-admin.ts
@@ -94,5 +94,5 @@ function resolveClient(args: Args) {
 
   if (!url || !key) throw new Error("Couldn't resolve url or key")
 
-  return createClient(url, key)
+  return createClient({ apiUrl: url, apiKey: key })
 }


### PR DESCRIPTION
I deployed an environment to a [linode cluster](https://cloud.linode.com/kubernetes/clusters/75539/summary) a few weeks ago, and it's been stable over that time. Linode is just another linux server provider, with better price-to-performance than GCP/AWS for our small-scale use. This PR merges in the configuration.

Note: This retains the temporary maple-prod2.alexjball.com domain I used to set up the cluster, before api.mapletestimony.org was set up. I will deploy to prod shortly, which will update everything to use api.mapletestimony.org. After that I'll remove the mape-prod2.alexjball.com domain.