### PR TITLE
Adds CurrentCommitteeCard component and story

### DIFF
--- a/components/Card/CardListItem.tsx
+++ b/components/Card/CardListItem.tsx
@@ -43,5 +43,8 @@ interface CardListItemsProps {
 
 export const CardListItems = (props: CardListItemsProps) => {
   const { items = [] } = props
+  if (items.length <= 0) {
+    return <></>
+  }
   return <ListGroup className="list-group-flush">{items}</ListGroup>
 }

--- a/components/CurrentCommitteeCard/CurrentCommitteeCard.tsx
+++ b/components/CurrentCommitteeCard/CurrentCommitteeCard.tsx
@@ -1,0 +1,44 @@
+import { FC } from "react"
+import styled from "styled-components"
+import { Card as MapleCard } from "../Card"
+import { Card as BootstrapCard } from "react-bootstrap"
+
+const Chamber = styled.span`
+  font-size: 16px;
+`
+
+const Committee = styled.div`
+  display: flex;
+  width: 100%;
+  text-align: center;
+  justify-content: center;
+  font-size: 22px;
+`
+
+const Container = styled.div`
+  max-width: 255px;
+  font-family: Nunito;
+`
+const Head = styled(BootstrapCard.Header)`
+  background-color: var(--bs-blue);
+  color: white;
+  font-size: 22px;
+`
+
+export const CurrentCommitteeCard: FC<{
+  chamber: "House" | "Senate"
+  committee: string
+}> = ({ committee, chamber }) => (
+  <Container>
+    <MapleCard
+      headerElement={<Head>Committee</Head>}
+      body={
+        <BootstrapCard.Body>
+          <Chamber>{chamber}</Chamber>
+          <br />
+          <Committee>{committee}</Committee>
+        </BootstrapCard.Body>
+      }
+    />
+  </Container>
+)

--- a/stories/billDetail/CurrentCommitteeCard.stories.tsx
+++ b/stories/billDetail/CurrentCommitteeCard.stories.tsx
@@ -1,7 +1,8 @@
+import { ComponentStory } from "@storybook/react"
 import { createMeta } from "stories/utils"
+import { CurrentCommitteeCard } from "../../components/CurrentCommitteeCard/CurrentCommitteeCard"
 
 // TODO: move into components directory
-const CurrentCommitteeCard = () => <div>TODO</div>
 
 export default createMeta({
   title: "Bill Detail/CurrentCommitteeCard",
@@ -10,4 +11,9 @@ export default createMeta({
   component: CurrentCommitteeCard
 })
 
-export const Primary = () => <CurrentCommitteeCard />
+const Template: ComponentStory<typeof CurrentCommitteeCard> = args => (
+  <CurrentCommitteeCard {...args} />
+)
+
+export const Primary = Template.bind({})
+Primary.args = { chamber: "House", committee: "Committee of Ways and Means" }

--- a/stories/billDetail/CurrentCommitteeCard.stories.tsx
+++ b/stories/billDetail/CurrentCommitteeCard.stories.tsx
@@ -2,8 +2,6 @@ import { ComponentStory } from "@storybook/react"
 import { createMeta } from "stories/utils"
 import { CurrentCommitteeCard } from "../../components/CurrentCommitteeCard/CurrentCommitteeCard"
 
-// TODO: move into components directory
-
 export default createMeta({
   title: "Bill Detail/CurrentCommitteeCard",
   figmaUrl:


### PR DESCRIPTION
Closes #838

# Summary
Adds `CurrentCommitteeCard` component and story
# Screenshots
_Almost_ like the mockup, however the alignment with the chamber and the committee name doesn't quite render the same.
<img width="966" alt="image" src="https://user-images.githubusercontent.com/11342238/206927921-71dee342-b385-4f96-8432-b4a7adc45f18.png">

Single line rendering still centers the committee name
<img width="958" alt="image" src="https://user-images.githubusercontent.com/11342238/206927979-2bbd9747-4bf9-47c4-9735-09085350afbd.png">

