### PR TITLE
Adds FollowingCard component

### DIFF
--- a/components/Card/CardTitle.tsx
+++ b/components/Card/CardTitle.tsx
@@ -15,7 +15,6 @@ export const CardTitle = (props: CardTitleProps) => {
   return (
     <CardBootstrap.Body className={`${styles.text} ${styles.body}`}>
       {imgSrc && <CardBootstrap.Img className={styles.img} src={imgSrc} />}
-
       <CardBootstrap.Body>
         {header && (
           <CardBootstrap.Title className={styles.title}>

--- a/components/FollowingCard/FollowingCard.tsx
+++ b/components/FollowingCard/FollowingCard.tsx
@@ -1,0 +1,58 @@
+import { FC } from "react"
+import styled from "styled-components"
+import { Card } from "../Card"
+
+export interface Organization {
+  name: string
+  iconSrc: string
+  href: string
+}
+
+interface Props {
+  organizations: Organization[]
+}
+
+const Container = styled.div`
+  max-width: 350px;
+`
+
+const Link = styled.a`
+  text-decoration: none;
+  color: inherit;
+  font-family: Nunito;
+  font-size: 20px;
+  line-height: 25px;
+`
+
+const Item = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 9px 22px;
+`
+
+export const FollowingCard: FC<Props> = ({ organizations }) => (
+  <Container>
+    <Card
+      header="Organizations"
+      subheader="Followed"
+      initialRowCount={7}
+      items={organizations.map(({ name, iconSrc, href }) => {
+        return (
+          <Item key={name}>
+            <img
+              src={iconSrc}
+              alt={"icon for " + name}
+              width="45px"
+              height="45px"
+              className="rounded-circle"
+            />
+            <Link href={href} target="_blank" rel="noopener">
+              {name}
+            </Link>
+          </Item>
+        )
+      })}
+    />
+  </Container>
+)

--- a/stories/dashboard/sidePanels/FollowingCard.stories.tsx
+++ b/stories/dashboard/sidePanels/FollowingCard.stories.tsx
@@ -9,7 +9,7 @@ export default createMeta({
   component: FollowingCard
 })
 
-export const Template: ComponentStory<typeof FollowingCard> = args => (
+const Template: ComponentStory<typeof FollowingCard> = args => (
   <FollowingCard {...args} />
 )
 

--- a/stories/dashboard/sidePanels/FollowingCard.stories.tsx
+++ b/stories/dashboard/sidePanels/FollowingCard.stories.tsx
@@ -1,7 +1,6 @@
+import { ComponentStory } from "@storybook/react"
 import { createMeta } from "stories/utils"
-
-// TODO: move into components directory
-const FollowingCard = () => <div>TODO</div>
+import { FollowingCard } from "../../../components/FollowingCard/FollowingCard"
 
 export default createMeta({
   title: "Dashboard/Side Panels/FollowingCard",
@@ -10,4 +9,58 @@ export default createMeta({
   component: FollowingCard
 })
 
-export const Primary = () => <FollowingCard />
+export const Template: ComponentStory<typeof FollowingCard> = args => (
+  <FollowingCard {...args} />
+)
+
+export const Primary = Template.bind({})
+
+const organizations = [
+  {
+    name: "Moms for Liberty",
+    href: "https://www.google.com",
+    iconSrc: "bostoncollegeicon.png"
+  },
+  {
+    name: "Moms for Boston",
+    href: "https://www.google.com",
+    iconSrc: "berkmankleincentericon.png"
+  },
+  {
+    name: "Moms for Sober Driving",
+    href: "https://www.google.com",
+    iconSrc: "bostoncollegeicon.png"
+  },
+  {
+    name: "Fathers for Liberty",
+    href: "https://www.google.com",
+    iconSrc: "bostoncollegeicon.png"
+  },
+  {
+    name: "Boston College",
+    href: "https://www.google.com",
+    iconSrc: "bostoncollegeicon.png"
+  },
+  {
+    name: "Green Sustainability",
+    href: "https://www.google.com",
+    iconSrc: "bostoncollegeicon.png"
+  },
+  {
+    name: "Boston Fire Department Unit",
+    href: "https://www.google.com",
+    iconSrc: "bostoncollegeicon.png"
+  },
+  {
+    name: "Parents Defending Education",
+    href: "https://www.google.com",
+    iconSrc: "bostoncollegeicon.png"
+  },
+  {
+    name: "Turning Point USA",
+    href: "https://www.google.com",
+    iconSrc: "bostoncollegeicon.png"
+  }
+]
+
+Primary.args = { organizations }


### PR DESCRIPTION
Closes #833
# Summary

Adds the FollowingCard component and completes its `Primary` story.

# Changes
 - Adds `FollowingCard` component
 - Adds `Primary` story for that component

# Screenshots

Default - 7 showing max like mockup
<img width="373" alt="image" src="https://user-images.githubusercontent.com/11342238/207512999-796f8dfe-c647-4ab3-8c07-e63693e51eed.png">

Expanded
<img width="367" alt="image" src="https://user-images.githubusercontent.com/11342238/207513083-2988f309-2cb5-4477-aaba-9f4b5f8ffa94.png">

# Notes

The `header` and `subheader` sizing in the underlying `Card` component looks like it has a layer too much of padding, but I'm not sure if we'd want to make that change everywhere to get it looking more like the snug mockup.
