### PR TITLE
updated slack channel on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ We are creating a new web platform called MAPLE (the Massachusetts Platform for 
 
 ## Essentials
 
-Join the [Code for Boston Slack](https://communityinviter.com/apps/cfb-public/default-badge) and our `#legislative-testimony` channel. Ask to join the Zenhub and Zeplin projects.
+Join the [Code for Boston Slack](https://communityinviter.com/apps/cfb-public/default-badge) and our `#maple-testimony` channel. Ask to join the Zenhub and Zeplin projects.
 
 Attend a [weekly hack night at Code for Boston](https://www.meetup.com/code-for-boston/events/) and join our group.
 


### PR DESCRIPTION
Updated the slack channel on the readme from "legislative-testimony" to "maple-testimony". No existing issue for this, just a small change for accuracy since I noticed the slack channel changed.

@alexjball 