### PR TITLE
Bill history bill links

### DIFF
--- a/components/bill/HistoryTable.tsx
+++ b/components/bill/HistoryTable.tsx
@@ -1,20 +1,39 @@
+import { siteUrl, Wrap } from "components/links"
 import styled from "styled-components"
 import { BillHistory } from "../db"
 
 export type HistoryProps = { billHistory: BillHistory }
 
+const path = "bill?id="
+const billNumToLink = (billStrNum: string) => {
+  return <Wrap href={siteUrl(path + billStrNum)}>{billStrNum}</Wrap>
+}
+const billRegex = new RegExp(/([HS]\d+)/)
+const linkConnectedBills = (action: string): JSX.Element => {
+  if (!billRegex.test(action)) {
+    return <span>{action}</span>
+  }
+  const words = action.split(billRegex)
+  const wordMap = words.map(w => billRegex.test(w) ? billNumToLink(w) : w)
+  return (
+    <>
+      {wordMap}
+    </>
+  )
+}
+
 const BillHistoryActionRows = ({ billHistory }: HistoryProps) => {
   return (
     <>
       {billHistory.map((billHistoryItem, index) => {
+        const { Date, Action, Branch } = billHistoryItem
         return (
           <tr key={index}>
             <td>
-              {billHistoryItem.Date.substring(5, 10)}-
-              {billHistoryItem.Date.substring(0, 4)}
+              {Date.substring(5, 10)}-{Date.substring(0, 4)}
             </td>
-            <td>{billHistoryItem.Action}</td>
-            <td>{billHistoryItem.Branch}</td>
+            <td>{linkConnectedBills(Action)}</td>
+            <td>{Branch}</td>
           </tr>
         )
       })}

--- a/components/bill/HistoryTable.tsx
+++ b/components/bill/HistoryTable.tsx
@@ -1,25 +1,21 @@
-import { siteUrl, Wrap } from "components/links"
+import { billSiteURL, Wrap } from "components/links"
 import styled from "styled-components"
 import { BillHistory } from "../db"
 
 export type HistoryProps = { billHistory: BillHistory }
 
-const path = "bill?id="
-const billNumToLink = (billStrNum: string) => {
-  return <Wrap href={siteUrl(path + billStrNum)}>{billStrNum}</Wrap>
-}
-const billRegex = new RegExp(/([HS]\d+)/)
 const linkConnectedBills = (action: string): JSX.Element => {
+  /* regex must have capture group for split to work */
+  const billRegex = new RegExp(/([HS]\d+)/) 
+  
   if (!billRegex.test(action)) {
-    return <span>{action}</span>
+    return <>{action}</>
   }
   const words = action.split(billRegex)
-  const wordMap = words.map(w => billRegex.test(w) ? billNumToLink(w) : w)
-  return (
-    <>
-      {wordMap}
-    </>
+  const wordMap = words.map(w =>
+    billRegex.test(w) ? <Wrap href={billSiteURL(w)}>{w}</Wrap> : w
   )
+  return <>{wordMap}</>
 }
 
 const BillHistoryActionRows = ({ billHistory }: HistoryProps) => {

--- a/components/links.tsx
+++ b/components/links.tsx
@@ -59,6 +59,10 @@ export function billURL(billNumber: string) {
   return `https://malegislature.gov/Bills/192/${billNumber}`
 }
 
+export function billSiteURL(billNumber: string) {
+  return siteUrl(`bill?id=${billNumber}`)
+}
+
 /** Not all bills have pdf's, only those without document text */
 export function billPdfUrl(id: string) {
   return `https://malegislature.gov/Bills/${currentGeneralCourt}/${id}.pdf`


### PR DESCRIPTION
In the bill history table actions, turns bill numbers into links to those bill's detail pages.