### PR TITLE
Update production for new general court and transition to Vercel

### DIFF
--- a/.github/workflows/deploy-frontend-dev.yml
+++ b/.github/workflows/deploy-frontend-dev.yml
@@ -6,8 +6,10 @@ on:
 
 jobs:
   build_and_deploy:
+    # Disable while transitioning to Vercel
+    if: false
     # Don't deploy forks, even if actions are enabled
-    if: github.repository_owner == 'codeforboston'
+    # if: github.repository_owner == 'codeforboston'
     runs-on: ubuntu-latest
     environment: dev
     steps:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -15,17 +15,10 @@ jobs:
         uses: actions/checkout@v2
       - name: Setup Build Environment
         uses: ./.github/actions/setup-repo
-      - name: Build Frontend
-        run: yarn run export
-        env:
-          NEXT_PUBLIC_FIREBASE_CONFIG: ${{ secrets.FIREBASE_CONFIG }}
-          NEXT_PUBLIC_TYPESENSE_API_URL: ${{ secrets.TYPESENSE_API_URL }}
-          NEXT_PUBLIC_TYPESENSE_SEARCH_API_KEY: ${{ secrets.TYPESENSE_API_KEY }}
-          NEXT_PUBLIC_LOG_ROCKET_ID: ${{ secrets.LOG_ROCKET_ID }}
       - name: Build and Deploy to Firebase
         uses: w9jds/firebase-action@master
         with:
-          args: deploy --force --only hosting,firestore,functions,storage
+          args: deploy --force --only firestore,functions,storage
         env:
           GCP_SA_KEY: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
           PROJECT_ID: digital-testimony-prod


### PR DESCRIPTION
Part of #917

Update production scraper for the new court 193. Once this is deployed I'll update the search index.

I've disabled firebase production hosting in prep for transitioning to Vercel. Production is on CI at https://maple-prod.vercel.app and we'll update the mapletestimony.org domain this week.

We continue to use firebase for auth/database/cloud code.