### PR TITLE
Adds SSN validation to testimony drafting stage

### DIFF
--- a/components/db/testimony/validation.ts
+++ b/components/db/testimony/validation.ts
@@ -1,0 +1,6 @@
+// https://stackoverflow.com/a/4087530/4531028
+const SSN_REGEX_PATTERN = /(?!(000|666|9))\d{3}-(?!00)\d{2}-(?!0000)\d{4}/gm;
+
+export function containsSocialSecurityNumber(text: string): boolean {
+  return new RegExp(SSN_REGEX_PATTERN).test(text);
+}

--- a/components/db/testimony/validation.ts
+++ b/components/db/testimony/validation.ts
@@ -1,6 +1,6 @@
 // https://stackoverflow.com/a/4087530/4531028
-const SSN_REGEX_PATTERN = /(?!(000|666|9))\d{3}-(?!00)\d{2}-(?!0000)\d{4}/gm;
+const SSN_REGEX_PATTERN = /(?!(000|666|9))\d{3}-(?!00)\d{2}-(?!0000)\d{4}/gm
 
 export function containsSocialSecurityNumber(text: string): boolean {
-  return new RegExp(SSN_REGEX_PATTERN).test(text);
+  return new RegExp(SSN_REGEX_PATTERN).test(text)
 }

--- a/components/publish/WriteTestimony.tsx
+++ b/components/publish/WriteTestimony.tsx
@@ -131,7 +131,8 @@ const Text = ({
   errors,
   inputProps
 }: UseWriteTestimony & { inputProps?: InputProps }) => {
-  const [touched, setTouched] = useState(false)
+  const didLoadSavedContent = !!content
+  const [touched, setTouched] = useState(didLoadSavedContent)
   return (
     <Input
       className="mt-3"

--- a/components/publish/redux.ts
+++ b/components/publish/redux.ts
@@ -13,6 +13,7 @@ import {
   WorkingDraft
 } from "../db"
 import { Maybe } from "../db/common"
+import { containsSocialSecurityNumber } from "../db/testimony/validation"
 
 export type Service = UseEditTestimony
 
@@ -275,6 +276,10 @@ const validateForm = ({ content, position, errors }: State) => {
   if (!content) errors.content = "Testimony content must not be empty"
   else if (content && content.length > maxTestimonyLength)
     errors.content = "Testimony content is too long"
+  else if (containsSocialSecurityNumber(content))  {
+    // TODO: include the offending number(s) in the error string.
+    errors.content = "Testimony must not contain social security numbers"
+  }
   else errors.content = undefined
 }
 

--- a/components/publish/redux.ts
+++ b/components/publish/redux.ts
@@ -276,11 +276,10 @@ const validateForm = ({ content, position, errors }: State) => {
   if (!content) errors.content = "Testimony content must not be empty"
   else if (content && content.length > maxTestimonyLength)
     errors.content = "Testimony content is too long"
-  else if (containsSocialSecurityNumber(content))  {
+  else if (containsSocialSecurityNumber(content)) {
     // TODO: include the offending number(s) in the error string.
     errors.content = "Testimony must not contain social security numbers"
-  }
-  else errors.content = undefined
+  } else errors.content = undefined
 }
 
 /** Reset the form, carrying over context props */


### PR DESCRIPTION
Resolves #925

# Changes

 - Adds SSN regex validation
 - Leverages existing errors validation via Redux

# Behavior

 - Refreshing the page with an SSN still in the draft also triggers the validation
 - Users will be bounced back to the draft page if they click Next

# Screenshot

<img width="995" alt="image" src="https://user-images.githubusercontent.com/11342238/216873392-cfcc9d3a-0d79-495f-ad43-3d6e0a677aa2.png">

