### PR TITLE
Edit Button + slider fix

### DIFF
--- a/components/TestimonyCard/Tabs.tsx
+++ b/components/TestimonyCard/Tabs.tsx
@@ -9,9 +9,19 @@ import styled from "styled-components"
 
 type onClickEventFunction = (e: Event, value: number) => void
 
-export const TabSlider = (props: { position: number; resizing: boolean }) => {
-  const { position, resizing } = props
-  return <TabSliderStyle width={220} position={position} resizing={resizing} />
+export const TabSlider = (props: {
+  width: number
+  position: number
+  resizing: boolean
+}) => {
+  const { width, position, resizing } = props
+  return (
+    <TabSliderStyle
+      width={width ?? 200}
+      position={position}
+      resizing={resizing}
+    />
+  )
 }
 
 export const TabSliderContainer = (props: { children?: JSX.Element[] }) => {
@@ -42,6 +52,7 @@ export const Tabs = (props: {
   const containerRef = useRef(null)
   const tabRefs = useRef<Array<HTMLDivElement | null>>([])
   const { childTabs, onChange, selectedTab } = props
+  const [sliderWidth, setSliderWidth] = useState(0)
   const [viewportWidth, setViewportWidth] = useState(
     typeof window ? undefined : window.innerWidth
   )
@@ -65,7 +76,8 @@ export const Tabs = (props: {
   useEffect(() => {
     const selected = tabRefs.current[selectedTab - 1]
     if (selected) {
-      setSliderPos(selected.offsetLeft - 70)
+      setSliderWidth(selected.clientWidth)
+      setSliderPos(selected.offsetLeft - 16)
     }
   }, [selectedTab, viewportWidth])
 
@@ -91,22 +103,25 @@ export const Tabs = (props: {
       <TabsContainer>{tabs}</TabsContainer>
       <TabSliderContainer>
         <TabSliderTrackStyle />
-        <TabSlider position={sliderPos} resizing={resizing} />
+        <TabSlider
+          width={sliderWidth}
+          position={sliderPos}
+          resizing={resizing}
+        />
       </TabSliderContainer>
     </ComponentContainer>
   )
 }
 
 const ComponentContainer = styled.div`
-  margin-bottom: 1rem;
-  padding: 1rem 2rem;
+  margin-bottom: 2%;
 `
 const TabsContainer = styled.div`
   display: flex;
   flex-direction: row;
-  padding-right: 2rem;
-  padding-left: 2rem;
-  justify-content: space-between;
+  justify-content: space-around;
+  margin: 0;
+  margin-top: 15px;
 `
 
 const TabStyle = styled.div<{ active: boolean }>`
@@ -125,14 +140,21 @@ const TabStyle = styled.div<{ active: boolean }>`
 const TabSliderContainerStyle = styled.div`
   display: flex;
   align-items: center;
+  width: 100%;
   height: 1px;
+  position: absolute;
 `
 const TabSliderTrackStyle = styled.div`
   background-color: #f1f1f1;
   align-self: center;
-  width: 100%;
-  height: 2px;
+  width: 75%;
+  height: 1px;
+  margin: 0;
+  padding: 0;
+  position: absolute;
   z-index: 9;
+  left: 50%;
+  transform: translateX(-55%);
 `
 
 export const TabSliderStyle = styled.div<{

--- a/components/TestimonyCard/TestimonyItem.tsx
+++ b/components/TestimonyCard/TestimonyItem.tsx
@@ -190,7 +190,7 @@ export const TestimonyItem = ({
 
           {isUser ? (
             <>
-              {canEdit && (
+              {onProfilePage && (
                 <Col>
                   <FooterButton variant="link">
                     <Internal

--- a/components/testimony/TestimonyDetailPage/PolicyActions.tsx
+++ b/components/testimony/TestimonyDetailPage/PolicyActions.tsx
@@ -35,7 +35,7 @@ export const PolicyActions: FC<PolicyActionsProps> = ({
   items.push(
     <PolicyActionItem
       key="add-testimony"
-      billName={`Add Testimony for ${billLabel}`}
+      billName={`${isUser ? "Edit" : "Add"} Testimony for ${billLabel}`}
       href={formUrl(bill.id, bill.court)}
     />
   )

--- a/components/testimony/TestimonyDetailPage/PolicyActions.tsx
+++ b/components/testimony/TestimonyDetailPage/PolicyActions.tsx
@@ -6,11 +6,19 @@ import { isNotNull } from "components/utils"
 import { FC, ReactElement } from "react"
 import { useCurrentTestimonyDetails } from "./testimonyDetailSlice"
 
+interface PolicyActionsProps {
+  className?: string
+  isUser?: boolean
+}
+
 const PolicyActionItem: FC<ListItemProps> = props => (
   <ListItem action active={false} variant="secondary" {...props} />
 )
 
-export const PolicyActions: FC<{ className?: string }> = ({ className }) => {
+export const PolicyActions: FC<PolicyActionsProps> = ({
+  className,
+  isUser
+}) => {
   const { bill } = useCurrentTestimonyDetails(),
     billLabel = formatBillId(bill.id)
 

--- a/components/testimony/TestimonyDetailPage/TestimonyDetailPage.tsx
+++ b/components/testimony/TestimonyDetailPage/TestimonyDetailPage.tsx
@@ -3,10 +3,15 @@ import { Col, Container, Row } from "react-bootstrap"
 import { BillTitle } from "./BillTitle"
 import { PolicyActions } from "./PolicyActions"
 import { RevisionHistory } from "./RevisionHistory"
+import { useCurrentTestimonyDetails } from "./testimonyDetailSlice"
 import { TestimonyDetail } from "./TestimonyDetail"
 import { VersionBanner } from "./TestimonyVersionBanner"
+import { useAuth } from "components/auth"
 
 export const TestimonyDetailPage: FC = () => {
+  const { authorUid } = useCurrentTestimonyDetails()
+  const { user } = useAuth()
+  const isUser = user?.uid === authorUid
   return (
     <>
       <VersionBanner fluid="xl" />

--- a/components/testimony/TestimonyDetailPage/TestimonyDetailPage.tsx
+++ b/components/testimony/TestimonyDetailPage/TestimonyDetailPage.tsx
@@ -26,7 +26,7 @@ export const TestimonyDetailPage: FC = () => {
           </Col>
 
           <Col md={4}>
-            <PolicyActions className="mb-4" />
+            <PolicyActions className="mb-4" isUser={isUser} />
             <RevisionHistory />
           </Col>
         </Row>


### PR DESCRIPTION
changes to slider tabs in ViewTestimony to allow for intended transitions.

Changes the conditional of the TestimonyItem Edit button to be visible when "onProfilePage".

Edit and Add Testimony use the same function(formUrl()) and properties. To have an "edit" action in the TestimonyDetail/PolicyActions, I used a conditional for nomenclature based on isUser, adding useAuth and useCurrentTestimonyDetails to define isUser within TestimonyDetailPage. isUser is added as a property via interface to PolicyActions to then take the conditional arg and change nomenclature.

ISSUE
https://github.com/codeforboston/maple/issues/1041