### PR TITLE
Adds ability for admin to delete testimony

### DIFF
--- a/components/TestimonyCallout/TestimonyCalloutSection.tsx
+++ b/components/TestimonyCallout/TestimonyCalloutSection.tsx
@@ -1,6 +1,5 @@
 import { Carousel, CarouselItem } from "react-bootstrap"
 import { useMediaQuery } from "usehooks-ts"
-import { deleteTestimony } from "../api/delete-testimony"
 import { Col, Container, Row } from "../bootstrap"
 import { useRecentTestimony } from "../db"
 import TestimonyCallout from "./TestimonyCallout"

--- a/components/TestimonyCallout/TestimonyCalloutSection.tsx
+++ b/components/TestimonyCallout/TestimonyCalloutSection.tsx
@@ -1,5 +1,6 @@
 import { Carousel, CarouselItem } from "react-bootstrap"
 import { useMediaQuery } from "usehooks-ts"
+import { deleteTestimony } from "../api/delete-testimony"
 import { Col, Container, Row } from "../bootstrap"
 import { useRecentTestimony } from "../db"
 import TestimonyCallout from "./TestimonyCallout"

--- a/components/api/delete-testimony.ts
+++ b/components/api/delete-testimony.ts
@@ -1,0 +1,14 @@
+import { mapleClient } from "./maple-client"
+
+/**
+ * Admin-only route for deleting testimony.
+ *
+ * Moves testimony from published to archived.
+ *
+ * @param uid user id, author of the testimony
+ * @param tid testimony id
+ * @returns 204 response (no body) if successful, or 4XX if not.
+ */
+export async function deleteTestimony(uid: string, tid: string) {
+  return mapleClient.delete(`/api/users/${uid}/testimony/${tid}`)
+}

--- a/pages/api/users/[uid]/testimony/[tid].ts
+++ b/pages/api/users/[uid]/testimony/[tid].ts
@@ -1,0 +1,61 @@
+import { NextApiRequest, NextApiResponse } from "next"
+import { z } from "zod"
+import { db } from "../../../../../components/server-api/init-firebase-admin"
+import { ensureAdminAuthenticated } from "../../../../../components/server-api/middleware-fns"
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  switch (req.method) {
+    case "DELETE":
+      return await _delete(req, res)
+    default:
+      res.status(404).end()
+  }
+}
+
+const QuerySchema = z.object({
+  uid: z.string(),
+  tid: z.string()
+})
+
+/**
+ * Admin-only route for deleting testimony.
+ *
+ * Moves testimony from published to archived in firestore.
+ *
+ * 204 no content if successful.
+ */
+async function _delete(req: NextApiRequest, res: NextApiResponse) {
+  const { query } = req
+  const token = await ensureAdminAuthenticated(req, res)
+  if (!token) {
+    return
+  }
+  const queryValidation = QuerySchema.safeParse(query)
+  if (!queryValidation.success) {
+    return res.status(400).json({
+      error: queryValidation.error
+    })
+  }
+  const { uid, tid } = queryValidation.data
+
+  const testimonyRef = await db.doc(`users/${uid}/publishedTestimony/${tid}`)
+  const testimonySnapshot = await testimonyRef.get()
+  if (!testimonySnapshot.exists) {
+    return res.status(404).json({
+      error: "Testimony doesn't exist."
+    })
+  }
+  const testimony = testimonySnapshot.data()
+
+  // add to archived
+  await db.doc(`users/${uid}/archivedTestimony/${tid}`).set({ ...testimony })
+
+  // remove from published
+  await testimonyRef.delete()
+
+  // ChatGPT recommmended this as the best return code for a DELETE
+  res.status(204).end()
+}


### PR DESCRIPTION
# Summary

Adds a new admin-only DELETE api route `/users/[uid]/testimony/[tid]` and corresponding front-end function

# Changes

 - Deleted testimony actually gets moved from published to archived.
 - Uses a batch to atomically "move" the testimony from published to archive

# Tests

![image](https://user-images.githubusercontent.com/11342238/229363459-22e49990-76c7-4431-a187-d1c9d0bedee9.png)

![image](https://user-images.githubusercontent.com/11342238/229363469-60aa1041-250c-4edb-b483-76888229795a.png)
