### PR TITLE
communicate that Bill link is clickable

### DIFF
--- a/components/bill/BillNumber.tsx
+++ b/components/bill/BillNumber.tsx
@@ -6,7 +6,12 @@ import { BillProps } from "./types"
 export const Styled = styled.div`
   font-size: 4rem;
   a {
-    text-decoration: none;
+    /*
+    design team asked to put decoration back; remove comment if people change their minds
+    https://github.com/codeforboston/maple/issues/998
+    */
+
+    // text-decoration: none;
     display: inline-flex;
     align-items: baseline;
   }


### PR DESCRIPTION
address issue #998 

communicate that Bill link is clickable
  removed text-decoration: none

other request to change "full text" to "show more" dealt with in other PRs dealing with Testimony component formatting