### PR TITLE
Bills search sidebar filter changes

### DIFF
--- a/components/search/SearchContainer.tsx
+++ b/components/search/SearchContainer.tsx
@@ -134,4 +134,14 @@ export const SearchContainer = styled.div`
     border-color: var(--bs-blue-100);
     color: var(--bs-blue);
   }
+
+  .ais-RefinementList-labelText {
+    white-space: normal;
+    display: inline-block;
+    width: 75%;
+  }
+
+  .ais-RefinementList-label {
+    border-bottom: dashed 1px;
+  }
 `

--- a/components/search/useRefinements.tsx
+++ b/components/search/useRefinements.tsx
@@ -55,6 +55,11 @@ export const useRefinements = () => {
       ...baseProps
     }),
     useRefinementListUiProps({
+      attribute: "currentCommittee",
+      ...baseProps,
+      searchablePlaceholder: "Current Committee"
+    }),
+    useRefinementListUiProps({
       attribute: "city",
       searchablePlaceholder: "City",
       ...baseProps
@@ -68,11 +73,6 @@ export const useRefinements = () => {
       attribute: "cosponsors",
       ...baseProps,
       searchablePlaceholder: "Cosponsor"
-    }),
-    useRefinementListUiProps({
-      attribute: "currentCommittee",
-      ...baseProps,
-      searchablePlaceholder: "Current Committee"
     })
   ]
 


### PR DESCRIPTION
Issue #1035 Moved committee search to top of bills search sidebar. Adjusted styling to search labels to display full text of committee. Added bottom border to delineate between items.
![committeeDisplay](https://user-images.githubusercontent.com/97904016/229368317-d3eef6d6-2f8b-4f84-9be5-81788b899b5b.PNG)
