### PR TITLE
(Temporary) hide bill search testimony counters

### DIFF
--- a/components/search/BillHit.tsx
+++ b/components/search/BillHit.tsx
@@ -102,7 +102,7 @@ const StyledCard = styled(Card)`
 
 const TestimonyCount = ({ hit }: { hit: Hit<BillRecord> }) => {
   return (
-    <div className="testimonyCount">
+    <div className="testimonyCount, visually-hidden">
       <FontAwesomeIcon className="endorse" icon={faCheckCircle} />
       {hit.endorseCount}
       <FontAwesomeIcon className="neutral" icon={faMinusCircle} />

--- a/components/search/BillHit.tsx
+++ b/components/search/BillHit.tsx
@@ -102,6 +102,7 @@ const StyledCard = styled(Card)`
 
 const TestimonyCount = ({ hit }: { hit: Hit<BillRecord> }) => {
   return (
+    // remove visually-hidden tag once Production search server is sorted out
     <div className="testimonyCount, visually-hidden">
       <FontAwesomeIcon className="endorse" icon={faCheckCircle} />
       {hit.endorseCount}


### PR DESCRIPTION
bill search counters set to hidden until the long term fix is in place

![counter1](https://user-images.githubusercontent.com/73559781/229548713-4a48743f-ad35-4cf0-9432-dc91e5d4a609.PNG)

![counter2](https://user-images.githubusercontent.com/73559781/229549023-d99d8131-ac26-47b7-a5a9-2038c90c789d.PNG)

per @alexjball:

"The quickest fix would be to hide the testimony counts in the ui. The correct fix is to fix the production deployment."

this PR will need to be replaced with the upcoming to fix to Production Deployment