### PR TITLE
hide delete icon on TestimonyItem

### DIFF
--- a/components/TestimonyCard/TestimonyItem.tsx
+++ b/components/TestimonyCard/TestimonyItem.tsx
@@ -128,7 +128,13 @@ export const TestimonyItem = ({
                 width={50}
               />
             </Internal>
-            <Internal className={styles.link} href={billLink}>
+            {/**
+             * visually-hidden until delete is ready at a later stage
+             */}
+            <Internal
+              className={`styles.link, visually-hidden`}
+              href={billLink}
+            >
               <Image
                 className="px-2 align-self-center"
                 src="/delete-testimony.svg"


### PR DESCRIPTION
closes #1058


            {/**
             * visually-hidden until delete is ready at a later stage
             */}
            <Internal
              className={`styles.link, visually-hidden`}
              href={billLink}
            >

![image](https://user-images.githubusercontent.com/73559781/229817377-f411ac50-46e4-4038-be61-f45732a9992a.png)
