### PR TITLE
Profile Links cleanup

### DIFF
--- a/components/ProfilePage/OrgContactInfo.tsx
+++ b/components/ProfilePage/OrgContactInfo.tsx
@@ -37,7 +37,11 @@ export const OrgContactInfo = ({ profile }: { profile?: Profile }) => {
 
       {website && (
         <ContactInfoRow>
-          <External className="d-flex justify-content-end" plain href={website}>
+          <External
+            className="d-flex justify-content-end"
+            plain
+            href={`https://${website}`}
+          >
             {website}
           </External>
         </ContactInfoRow>

--- a/components/db/profile/profile.ts
+++ b/components/db/profile/profile.ts
@@ -6,6 +6,7 @@ import { Frequency, OrgCategory, useAuth } from "../../auth"
 import { firestore, storage } from "../../firebase"
 import { useProfileState } from "./redux"
 import { Profile, ProfileMember, SocialLinks, ContactInfo } from "./types"
+import { cleanSocialLinks, cleanOrgURL } from "./urlCleanup"
 
 export type ProfileHook = ReturnType<typeof useProfile>
 
@@ -249,6 +250,8 @@ function updateOrgCategory(uid: string, category: OrgCategory) {
 }
 
 function updateSocial(uid: string, network: keyof SocialLinks, link: string) {
+  link = cleanSocialLinks(network, link)
+
   return setDoc(
     profileRef(uid),
     { social: { [network]: link ?? deleteField() } },
@@ -261,6 +264,11 @@ function updateContactInfo(
   contactType: keyof ContactInfo,
   contact: string | number
 ) {
+  if (contactType === "website") {
+    contact = contact.toString()
+    contact = cleanOrgURL(contact)
+  }
+
   return setDoc(
     profileRef(uid),
     { contactInfo: { [contactType]: contact ?? deleteField() } },

--- a/components/db/profile/urlCleanup.ts
+++ b/components/db/profile/urlCleanup.ts
@@ -1,0 +1,33 @@
+import { SocialLinks } from ".."
+
+export function cleanSocialLinks(network: keyof SocialLinks, link: string) {
+  let path = link
+  if (network !== "linkedIn") {
+    if (path.includes(".com/")) {
+      const index: number = path.indexOf(".com/") + 5
+      path = path.substring(index)
+    }
+  }
+
+  return path
+
+  // above should cover twitter, facebook, instagram. Need to come up with a solution for linkedin, as individuals (/in/name), companies (/company/name), schools (/school/name) have different subdirectories. Current code on front end links directly to individuals only
+}
+
+export function cleanOrgURL(url: string) {
+  let parsed = url
+  // if (url.includes("www.")) {
+  //   const index: number = url.indexOf("www.") + 4
+  //   parsed = url.substring(index)
+  // else } <-- add back if we want to scrub "www."
+  if (url.includes("http://")) {
+    const index: number = url.indexOf("http://") + 7
+    parsed = url.substring(index)
+  } else if (url.includes("https://")) {
+    const index: number = url.indexOf("https://") + 8
+    parsed = url.substring(index)
+  }
+  return parsed
+
+  // to streamline entry for users, we will allow orgs to enter their website with or without https:// prefix. If it is entered, this function scrubs it as we are already adding for all org urls.
+}


### PR DESCRIPTION
Added new functions to clean up social media links and org external website links added via edit profile.

Social Media Links:
- scrubbed anything up to and including ".com/" for facebook, instagram, and twitter, as those are hardcoded into the icons
- we will need to review linkedIn further. individuals, companies, and schools all use different paths, so we will need to determine how we want to handle that. Currently, the icon link is hard coded to "/in/name-of-person" - this will likely not work for orgs as their linkedin probably points to a company profile eg: https://www.linkedin.com/company/mass-rivers/

Org URLs:
- scrubbed http prefixes and hard-coded https:// into the external link. 
- orgs don't have to be instructed about the format for how to enter their url
- org profiles look cleaner without the prefix displaying in the text for their link
- links redirect appropriately 

Closes Issue #1069 