### PR TITLE
Update about page and footer

### DIFF
--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -107,6 +107,18 @@ const ResourcesLinks = () => {
       >
         {t("links.resourcesLegislators")}
       </ExternalNavLink>
+      <ExternalNavLink
+        className={styles.footerLink}
+        href="https://github.com/codeforboston/maple"
+      >
+        {t("links.resourcesGitHub")}
+      </ExternalNavLink>
+      <ExternalNavLink
+        className={styles.footerLink}
+        href="https://opencollective.com/mapletestimony"
+      >
+        {t("links.resourcesOpenCollective")}
+      </ExternalNavLink>
     </>
   )
 }

--- a/components/about/SupportMapleCardContent/SupportMapleCardContent.js
+++ b/components/about/SupportMapleCardContent/SupportMapleCardContent.js
@@ -7,7 +7,7 @@ const DonateCardContent = () => {
       <p>
         <span>{`${t("donate.bodytextOne")} `}</span>
         <a
-          href="https://opencollective.com/maple-massachusetts-platform-for-legislative-engagement"
+          href="https://opencollective.com/mapletestimony"
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/public/locales/en/footer.json
+++ b/public/locales/en/footer.json
@@ -19,6 +19,8 @@
     "aboutMission": "Our Mission & Goals",
     "aboutTeam": "Our Team",
     "resourcesLegislators": "Find your Legislators",
+    "resourcesGitHub": "MAPLE on GitHub",
+    "resourcesOpenCollective": "MAPLE OpenCollective",
     "teamNEU": "Northeastern University NuLawLab",
     "teamCFB": "Code for Boston",
     "teamHarvard": "Harvard Berkman Klein Center"


### PR DESCRIPTION
Update the link to our OpenCollective page to reflect the new URL, https://opencollective.com/mapletestimony

Also added GitHub and OC links to the footer.