### PR TITLE
fix for google log in claims & profile wipeout

### DIFF
--- a/components/auth/hooks.ts
+++ b/components/auth/hooks.ts
@@ -117,8 +117,17 @@ export function useSignInWithPopUp() {
   return useFirebaseFunction(async (provider: AuthProvider) => {
     const credentials = await signInWithPopup(auth, provider)
 
-    await finishSignup({ requestedRole: "user" })
-
-    await setProfile(credentials.user.uid, {})
+    const { claims } = await credentials.user.getIdTokenResult()
+    if (!claims?.role) {
+      // The user has not yet finished signing up
+      await finishSignup({ requestedRole: "user" })
+      await Promise.all([
+        setProfile(credentials.user.uid, {
+          fullName: credentials.user.displayName ?? "New User"
+        })
+      ])
+    }
+    console.log(credentials)
+    return credentials
   })
 }


### PR DESCRIPTION
adds logic in useSignInWithPopUp that checks whether the user has already finished signing up ((has claims) before setting the users role and initiating a profile
this fixes the problem where signing in with google wiped out the users claims and reset their profile info

this doesn't address directing the google users to the policy agreement when signing up, or that the sign in modal hangs when pop up closes 