### PR TITLE
new accounts default to public: true

### DIFF
--- a/components/ProfilePage/ProfilePage.tsx
+++ b/components/ProfilePage/ProfilePage.tsx
@@ -42,7 +42,14 @@ export function ProfilePage(profileprops: {
   const testimony = usePublishedTestimonyListing({
     uid: profileprops.id
   })
+
   const { t } = useTranslation("profile")
+
+  const bannerContent = profile?.public ? (
+    <Banner> {t("content.publicProfile")} </Banner>
+  ) : (
+    <Banner> {t("content.privateProfile")} </Banner>
+  )
 
   return (
     <>
@@ -54,7 +61,7 @@ export function ProfilePage(profileprops: {
         <>
           {profile ? (
             <>
-              {isUser && <Banner> {t("content.viewingProfile")} </Banner>}
+              {isUser && bannerContent}
               <StyledContainer>
                 <ProfileHeader
                   isUser={isUser}

--- a/components/ProfilePage/ProfilePage.tsx
+++ b/components/ProfilePage/ProfilePage.tsx
@@ -61,6 +61,7 @@ export function ProfilePage(profileprops: {
         <>
           {profile ? (
             <>
+              {isUser && <Banner> {t("content.viewingProfile")} </Banner>}
               {isUser && bannerContent}
               <StyledContainer>
                 <ProfileHeader

--- a/components/auth/hooks.ts
+++ b/components/auth/hooks.ts
@@ -74,14 +74,16 @@ export function useCreateUserWithEmailAndPassword(isOrg: boolean) {
         await Promise.all([
           setProfile(credentials.user.uid, {
             fullName,
-            orgCategories: categories
+            orgCategories: categories,
+            public: true
           }),
           sendEmailVerification(credentials.user)
         ])
       } else {
         await Promise.all([
           setProfile(credentials.user.uid, {
-            fullName
+            fullName,
+            public: true
           }),
           sendEmailVerification(credentials.user)
         ])

--- a/public/locales/en/profile.json
+++ b/public/locales/en/profile.json
@@ -8,8 +8,9 @@
     "editProfile": "Edit\u00A0Profile"
   },
   "content": {
-    "publicProfile": "Your profile is currently public. Others can view your profile page.",
-    "privateProfile": "Your profile is currently private. Your name is still associated with published testimonies but your profile page is hidden.",
+    "viewingProfile": "Currently viewing your profile",
+    "publicProfile": "Your profile is currently public. You can change this in \"settings\"",
+    "privateProfile": "Your profile is currently private. You can change this in \"settings\"",
     "statePurpose": "State your purpose",
     "noLegislatorInfo": "No legislator information given"
     },

--- a/public/locales/en/profile.json
+++ b/public/locales/en/profile.json
@@ -8,7 +8,8 @@
     "editProfile": "Edit\u00A0Profile"
   },
   "content": {
-    "viewingProfile": "Currently viewing your profile",
+    "publicProfile": "Your profile is currently public. Others can view your profile page.",
+    "privateProfile": "Your profile is currently private. Your name is still associated with published testimonies but your profile page is hidden.",
     "statePurpose": "State your purpose",
     "noLegislatorInfo": "No legislator information given"
     },

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -3,6 +3,7 @@
 _Add a short summary of the changes, and a reference to the original issue using `#` and the issue number, like #1_
 
 # Checklist
+
 - [ ] On the frontend, I've made my strings translate-able.
 - [ ] If I've added shared components, I've added a storybook story.
 - [ ] I've made pages responsive and look good on mobile.


### PR DESCRIPTION
# Summary

As of this PR, when a user or potential org registers, they are set as "public"

Under the orange bar on the top of the profile: Your profile is currently public. Others can view your profile page. OR Your profile is currently private. Your name is still associated with published testimonies but your profile page is hidden.

 - #1178
 -  #1186

# Checklist

- [ ] Keep the current toggle on settings, but also add the toggle button to the profile under the "Edit Profile" button
- [ ] On the frontend, I've made my strings translate-able.
- [ ] If I've added shared components, I've added a storybook story.
- [ ] I've made pages responsive and look good on mobile.

# Screenshots

![image](https://github.com/codeforboston/maple/assets/73559781/67a75a21-94cd-427c-9758-f6c5c60ba4df)

![image](https://github.com/codeforboston/maple/assets/73559781/431d7544-b183-4cd7-9679-8322d0269356)

# Known issues

None at this time

# Steps to test/reproduce

1. go to Maple's site and make sure you are signed out
2. sign up a test account
3. navigate to Edit Profile
4. hit the * Settings button
5. check that the settings modal says, "Your profile is currently public. Others can view your profile page"
6. navigate to View Profile
7. make sure the orange banner near the top matches public settings