### PR TITLE
Set of fixes

### DIFF
--- a/components/ProfilePage/ProfileHeader.tsx
+++ b/components/ProfilePage/ProfileHeader.tsx
@@ -1,14 +1,15 @@
+import { flags } from "components/featureFlags"
+import { FollowButton } from "components/shared/FollowButton"
 import { Col, Stack } from "../bootstrap"
-import {
-  Header,
-  ProfileDisplayName,
-  OrgIconLarge,
-  UserIcon
-} from "./StyledProfileComponents"
+import { Profile } from "../db"
 import { EditProfileButton } from "./EditProfileButton"
 import { OrgContactInfo } from "./OrgContactInfo"
-import { Profile } from "../db"
-import { FollowButton } from "components/shared/FollowButton"
+import {
+  Header,
+  OrgIconLarge,
+  ProfileDisplayName,
+  UserIcon
+} from "./StyledProfileComponents"
 
 export const ProfileHeader = ({
   isUser,
@@ -48,7 +49,9 @@ export const ProfileHeader = ({
               {isUser ? (
                 <EditProfileButton isOrg={isOrg} isMobile={isMobile} />
               ) : (
-                <FollowButton profileid={profileid} />
+                <>
+                  {flags().followOrg && <FollowButton profileid={profileid} />}
+                </>
               )}
             </>
           )}

--- a/components/TestimonyCard/ViewTestimony.tsx
+++ b/components/TestimonyCard/ViewTestimony.tsx
@@ -1,17 +1,18 @@
-import { Row, Col, Form } from "react-bootstrap"
-import React, { useState } from "react"
-import { UsePublishedTestimonyListing } from "../db"
-import { TitledSectionCard } from "../shared"
-import { TestimonyItem } from "./TestimonyItem"
 import { NoResults } from "components/search/NoResults"
-import { SortTestimonyDropDown } from "./SortTestimonyDropDown"
-import { Card as MapleCard } from "../Card"
-import { Card as BootstrapCard } from "react-bootstrap"
-import styled from "styled-components"
 import { PaginationButtons } from "components/table"
-import { Tabs, Tab } from "./Tabs"
-import { useTranslation } from "next-i18next"
+import { TFunction, useTranslation } from "next-i18next"
+import { useState } from "react"
+import { Card as BootstrapCard, Col, Row } from "react-bootstrap"
+import styled from "styled-components"
+import { Card as MapleCard } from "../Card"
 import { useAuth } from "../auth"
+import {
+  Testimony,
+  UsePublishedTestimonyListing
+} from "../db"
+import { SortTestimonyDropDown } from "./SortTestimonyDropDown"
+import { Tab, Tabs } from "./Tabs"
+import { TestimonyItem } from "./TestimonyItem"
 
 const Container = styled.div`
   font-family: Nunito;
@@ -108,12 +109,12 @@ const ViewTestimony = (
               <div>
                 {onProfilePage && (
                   <Row className="justify-content-between mb-4">
-                    <Col className="d-flex align-items-center">
-                      {t("viewTestimony.showing1")}
-                      {testimony.length}
-                      {t("viewTestimony.outOf")}
-                      {testimony.length}
-                    </Col>
+                    <ShowPaginationSummary
+                      testimony={testimony}
+                      pagination={pagination}
+                      t={t}
+                    />
+
                     <Col xs="auto">
                       <SortTestimonyDropDown
                         orderBy={orderBy}
@@ -160,3 +161,33 @@ const ViewTestimony = (
 }
 
 export default ViewTestimony
+
+function ShowPaginationSummary({
+  testimony,
+  pagination,
+  t
+}: {
+  testimony: Testimony[]
+  pagination: { currentPage: number; itemsPerPage: number }
+  t: TFunction
+}) {
+  if (testimony.length < 1) {
+    return null
+  }
+  const { currentPage, itemsPerPage } = pagination
+
+  const currentPageStart = (currentPage - 1) * itemsPerPage
+  let currentPageEnd = currentPage * itemsPerPage
+  if (currentPageEnd > testimony.length) {
+    currentPageEnd = (currentPageStart) + (testimony.length % itemsPerPage)
+  }
+  const totalItems = testimony.length
+
+  return (
+    <Col className="d-flex align-items-center">
+      {t("viewTestimony.showing")} {currentPageStart + 1}&ndash;{currentPageEnd}{" "}
+      {t("viewTestimony.outOf")}
+      {totalItems}
+    </Col>
+  )
+}

--- a/components/TestimonyCard/ViewTestimony.tsx
+++ b/components/TestimonyCard/ViewTestimony.tsx
@@ -6,10 +6,7 @@ import { Card as BootstrapCard, Col, Row } from "react-bootstrap"
 import styled from "styled-components"
 import { Card as MapleCard } from "../Card"
 import { useAuth } from "../auth"
-import {
-  Testimony,
-  UsePublishedTestimonyListing
-} from "../db"
+import { Testimony, UsePublishedTestimonyListing } from "../db"
 import { SortTestimonyDropDown } from "./SortTestimonyDropDown"
 import { Tab, Tabs } from "./Tabs"
 import { TestimonyItem } from "./TestimonyItem"
@@ -179,7 +176,7 @@ function ShowPaginationSummary({
   const currentPageStart = (currentPage - 1) * itemsPerPage
   let currentPageEnd = currentPage * itemsPerPage
   if (currentPageEnd > testimony.length) {
-    currentPageEnd = (currentPageStart) + (testimony.length % itemsPerPage)
+    currentPageEnd = currentPageStart + (testimony.length % itemsPerPage)
   }
   const totalItems = testimony.length
 

--- a/components/bill/BillDetails.tsx
+++ b/components/bill/BillDetails.tsx
@@ -1,4 +1,7 @@
 import { flags } from "components/featureFlags"
+import { FollowButton } from "components/shared/FollowButton"
+import { isCurrentCourt } from "functions/src/shared"
+import { useTranslation } from "next-i18next"
 import styled from "styled-components"
 import { Col, Container, Row } from "../bootstrap"
 import { TestimonyFormPanel } from "../publish"
@@ -7,14 +10,11 @@ import { Back } from "./Back"
 import { BillNumber, Styled } from "./BillNumber"
 import { BillTestimonies } from "./BillTestimonies"
 import BillTrackerConnectedView from "./BillTracker"
-// import { LobbyingTable } from "./LobbyingTable"
+import { LobbyingTable } from "./LobbyingTable"
 import { Committees, Hearing, Sponsors } from "./SponsorsAndCommittees"
 import { Status } from "./Status"
 import { Summary } from "./Summary"
 import { BillProps } from "./types"
-import { FollowButton } from "components/shared/FollowButton"
-import { useTranslation } from "next-i18next"
-import { isCurrentCourt } from "functions/src/shared"
 
 const StyledContainer = styled(Container)`
   font-family: "Nunito";
@@ -72,7 +72,9 @@ export const BillDetails = ({ bill }: BillProps) => {
           <Col md={8}>
             <Sponsors bill={bill} className="mt-4 pb-1" />
             <BillTestimonies bill={bill} className="mt-4" />
-            {/*<LobbyingTable bill={bill} className="mt-4 pb-1" /> This feature not yet ready*/}
+            {flags().lobbyingTable && (
+              <LobbyingTable bill={bill} className="mt-4 pb-1" />
+            )}
           </Col>
           <Col md={4}>
             <Committees bill={bill} className="mt-4 pb-1" />

--- a/components/bill/SponsorsAndCommittees.tsx
+++ b/components/bill/SponsorsAndCommittees.tsx
@@ -8,6 +8,9 @@ import { Cosponsors } from "./Cosponsors"
 import { LabeledContainer } from "./LabeledContainer"
 import styles from "./SponsorsAndCommittees.module.css"
 import { BillProps } from "./types"
+import { DisplayUpcomingHearing } from "components/search/bills/BillHit"
+import { dateInFuture } from "components/db/events"
+import { Timestamp } from "firebase/firestore"
 
 const HearingDate = styled.div`
   font-weight: 500;
@@ -50,16 +53,14 @@ export const Committees: FC<BillProps> = ({ bill, className }) => {
 export const Hearing: FC<BillProps> = ({ bill, className }) => {
   return (
     <>
-      {!bill.nextHearingAt?.seconds ? null : (
+      {bill.nextHearingAt && dateInFuture(bill.nextHearingAt) ? (
         <LabeledContainer className={className}>
           <HearingDate>
             Hearing Scheduled for{" "}
-            {bill.nextHearingAt?.seconds
-              ? format(fromUnixTime(bill.nextHearingAt?.seconds), "MMM d, y p")
-              : null}
+            {format(fromUnixTime(bill.nextHearingAt?.seconds), "MMM d, y p")}
           </HearingDate>
         </LabeledContainer>
-      )}
+      ) : null}
     </>
   )
 }

--- a/components/db/events.ts
+++ b/components/db/events.ts
@@ -8,6 +8,7 @@ import {
 import { useAsync } from "react-async-hook"
 import { firestore } from "../firebase"
 import { midnight, nullableQuery } from "./common"
+import { DateTime } from "luxon"
 
 /** The timezone used for datetime strings returned by the API. */
 export const timeZone = "America/New_York"
@@ -99,3 +100,32 @@ export async function listUpcomingEvents(types?: Event["type"][]) {
 
   return result.docs.map(d => d.data() as Event)
 }
+
+
+/** returns true if input is a timestamp and false if not */
+export const isTimestamp = (t: any): t is Timestamp => {
+  return t && t.seconds !== undefined && t.nanoseconds !== undefined
+}
+
+/** converts time representation to a Timestamp if possible or else throws error */
+export function parseTimestamp(t: any): Timestamp {
+  if (isTimestamp(t)) return t
+  if (t && typeof t === "object" && t._seconds !== undefined)
+    return new Timestamp(t._seconds, t._nanoseconds)
+  if (t && typeof t === "number") {
+    if (t > 1_000_000_000_000) t = Math.floor(t / 1000)
+    return new Timestamp(t, 0)
+  }
+  throw Error(`Invalid timestamp: ${t}`)
+}
+
+/** returns true if date is current date or later, otherwise returns false. throws error if input can't be parsed as a Timestamp */
+export function dateInFuture(
+  a: Timestamp | number | object | undefined,
+) {
+  if (a === undefined) return false
+  const today = Timestamp.now().seconds
+  const eventDate = parseTimestamp(a).seconds
+
+  return eventDate >= today
+} 

--- a/components/db/events.ts
+++ b/components/db/events.ts
@@ -101,7 +101,6 @@ export async function listUpcomingEvents(types?: Event["type"][]) {
   return result.docs.map(d => d.data() as Event)
 }
 
-
 /** returns true if input is a timestamp and false if not */
 export const isTimestamp = (t: any): t is Timestamp => {
   return t && t.seconds !== undefined && t.nanoseconds !== undefined
@@ -120,12 +119,10 @@ export function parseTimestamp(t: any): Timestamp {
 }
 
 /** returns true if date is current date or later, otherwise returns false. throws error if input can't be parsed as a Timestamp */
-export function dateInFuture(
-  a: Timestamp | number | object | undefined,
-) {
+export function dateInFuture(a: Timestamp | number | object | undefined) {
   if (a === undefined) return false
   const today = Timestamp.now().seconds
   const eventDate = parseTimestamp(a).seconds
 
   return eventDate >= today
-} 
+}

--- a/components/featureFlags.ts
+++ b/components/featureFlags.ts
@@ -6,7 +6,7 @@ export const FeatureFlags = z.object({
   /** Notifications and follows */
   notifications: z.boolean().default(false),
   /** Bill Tracker on Bill Details */
-  billTracker: z.boolean().default(false), 
+  billTracker: z.boolean().default(false),
   /** Follow button for organizations */
   followOrg: z.boolean().default(false),
   /** Lobbying Table */

--- a/components/featureFlags.ts
+++ b/components/featureFlags.ts
@@ -6,7 +6,11 @@ export const FeatureFlags = z.object({
   /** Notifications and follows */
   notifications: z.boolean().default(false),
   /** Bill Tracker on Bill Details */
-  billTracker: z.boolean().default(false)
+  billTracker: z.boolean().default(false), 
+  /** Follow button for organizations */
+  followOrg: z.boolean().default(false),
+  /** Lobbying Table */
+  lobbyingTable: z.boolean().default(false)
 })
 
 export type FeatureFlags = z.infer<typeof FeatureFlags>
@@ -22,17 +26,23 @@ const defaults: Record<Env, FeatureFlags> = {
   development: {
     testimonyDiffing: false,
     notifications: true,
-    billTracker: true
+    billTracker: true,
+    followOrg: false,
+    lobbyingTable: false
   },
   production: {
     testimonyDiffing: false,
     notifications: false,
-    billTracker: false
+    billTracker: false,
+    followOrg: false,
+    lobbyingTable: false
   },
   test: {
     testimonyDiffing: false,
     notifications: false,
-    billTracker: false
+    billTracker: false,
+    followOrg: false,
+    lobbyingTable: false
   }
 }
 

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -63,7 +63,7 @@ const TopNav: React.FC = () => {
       <Container>
         <div className={styles.navbar_boxes_container}>
           <div className={styles.navbar_box}>
-            <Navbar expand={false}>
+            <Navbar expand={false} expanded={isExpanded}>
               <Navbar.Brand>
                 <Navbar.Toggle aria-controls="topnav" onClick={toggleNav} />
               </Navbar.Brand>

--- a/components/search/bills/BillHit.tsx
+++ b/components/search/bills/BillHit.tsx
@@ -115,6 +115,10 @@ const TestimonyCount = ({ hit }: { hit: Hit<BillRecord> }) => {
 
 export const BillHit = ({ hit }: { hit: Hit<BillRecord> }) => {
   const url = maple.bill({ id: hit.number, court: hit.court })
+  const today = new Date()
+  const hearingDate = hit.nextHearingAt && hit.nextHearingAt / 1000 // convert to seconds
+  const isUpcomingHearing = hearingDate ? today < fromUnixTime(hearingDate) : false
+
   return (
     <Link href={url}>
       <a style={{ all: "unset" }} className="w-100">
@@ -151,10 +155,9 @@ export const BillHit = ({ hit }: { hit: Hit<BillRecord> }) => {
               </Col>
             </div>
           </Card.Body>
-          {hit.nextHearingAt ? (
+          {isUpcomingHearing ? (
             <Card.Footer className="card-footer">
-              Hearing Scheduled{" "}
-              {format(fromUnixTime(hit.nextHearingAt / 1000), "M/d/y p")}
+              Hearing Scheduled {format(fromUnixTime(hearingDate!), "M/d/y p")}
             </Card.Footer>
           ) : null}
         </StyledCard>

--- a/components/search/bills/BillHit.tsx
+++ b/components/search/bills/BillHit.tsx
@@ -12,6 +12,9 @@ import Link from "next/link"
 import styled from "styled-components"
 import { Card, Col } from "../../bootstrap"
 import { formatBillId } from "../../formatting"
+import { Timestamp } from "firebase/firestore"
+import { DateTime } from "luxon"
+import { dateInFuture } from "components/db/events"
 
 type BillRecord = {
   number: string
@@ -113,6 +116,20 @@ const TestimonyCount = ({ hit }: { hit: Hit<BillRecord> }) => {
   )
 }
 
+export const DisplayUpcomingHearing = ({
+  nextHearingAt,
+  children
+}: {
+  nextHearingAt: number | Timestamp | undefined
+  children: React.ReactNode
+}) => {
+  if (nextHearingAt && dateInFuture(nextHearingAt)) {
+    return <>{children}</>
+  }
+
+  return null
+}
+
 export const BillHit = ({ hit }: { hit: Hit<BillRecord> }) => {
   const url = maple.bill({ id: hit.number, court: hit.court })
   const today = new Date()
@@ -157,7 +174,7 @@ export const BillHit = ({ hit }: { hit: Hit<BillRecord> }) => {
               </Col>
             </div>
           </Card.Body>
-          {isUpcomingHearing ? (
+          {hit.nextHearingAt && dateInFuture(hit.nextHearingAt) ? (
             <Card.Footer className="card-footer">
               Hearing Scheduled {format(fromUnixTime(hearingDate!), "M/d/y p")}
             </Card.Footer>

--- a/components/search/bills/BillHit.tsx
+++ b/components/search/bills/BillHit.tsx
@@ -117,7 +117,9 @@ export const BillHit = ({ hit }: { hit: Hit<BillRecord> }) => {
   const url = maple.bill({ id: hit.number, court: hit.court })
   const today = new Date()
   const hearingDate = hit.nextHearingAt && hit.nextHearingAt / 1000 // convert to seconds
-  const isUpcomingHearing = hearingDate ? today < fromUnixTime(hearingDate) : false
+  const isUpcomingHearing = hearingDate
+    ? today < fromUnixTime(hearingDate)
+    : false
 
   return (
     <Link href={url}>

--- a/components/search/bills/BillSearch.tsx
+++ b/components/search/bills/BillSearch.tsx
@@ -18,7 +18,7 @@ import { SearchErrorBoundary } from "../SearchErrorBoundary"
 import { useRouting } from "../useRouting"
 import { BillHit } from "./BillHit"
 import { useBillRefinements } from "./useBillRefinements"
-import { SortBy } from "../SortBy";
+import { SortBy } from "../SortBy"
 import { getServerConfig } from "../common"
 
 const searchClient = new TypesenseInstantSearchAdapter({

--- a/components/search/testimony/TestimonyHit.tsx
+++ b/components/search/testimony/TestimonyHit.tsx
@@ -7,6 +7,7 @@ import { formatBillId } from "components/formatting"
 import { useBill } from "components/db/bills"
 import { FollowButton } from "components/shared/FollowButton"
 import { Image } from "react-bootstrap"
+import { flags } from "components/featureFlags"
 
 export const TestimonyHit = ({ hit }: { hit: Hit<Testimony> }) => {
   const url = maple.testimony({ publishedId: hit.id })
@@ -62,7 +63,7 @@ const TestimonyResult = ({ hit }: { hit: Hit<Testimony> }) => {
         <span style={{ flexGrow: 1 }}>
           <b>Written by {writtenBy}</b>
         </span>
-        {isOrg && <FollowButton profileid={hit.authorUid} />}
+        {flags().followOrg && isOrg && <FollowButton profileid={hit.authorUid} />}
       </div>
       <hr />
       <div style={{ display: "flex", alignItems: "center" }}>

--- a/components/search/testimony/TestimonyHit.tsx
+++ b/components/search/testimony/TestimonyHit.tsx
@@ -63,7 +63,9 @@ const TestimonyResult = ({ hit }: { hit: Hit<Testimony> }) => {
         <span style={{ flexGrow: 1 }}>
           <b>Written by {writtenBy}</b>
         </span>
-        {flags().followOrg && isOrg && <FollowButton profileid={hit.authorUid} />}
+        {flags().followOrg && isOrg && (
+          <FollowButton profileid={hit.authorUid} />
+        )}
       </div>
       <hr />
       <div style={{ display: "flex", alignItems: "center" }}>

--- a/components/search/useRefinements.tsx
+++ b/components/search/useRefinements.tsx
@@ -1,6 +1,6 @@
 import {
   RefinementListUiComponent,
-  useInstantSearch,
+  useInstantSearch
 } from "@alexjball/react-instantsearch-hooks-web"
 import { faFilter } from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"

--- a/functions/src/malegislature.ts
+++ b/functions/src/malegislature.ts
@@ -27,7 +27,9 @@ import { MemberContent } from "./members/types"
 function addCertificates() {
   const rootCas = createRootCas()
   // rootCas.addFile(__dirname + "/ssl/DigiCert TLS RSA SHA256 2020 CA1.pem")
-  rootCas.addFile(__dirname + "/ssl/DigiCertGlobalG2TLSRSASHA2562020CA1.crt.pem")
+  rootCas.addFile(
+    __dirname + "/ssl/DigiCertGlobalG2TLSRSASHA2562020CA1.crt.pem"
+  )
   require("https").globalAgent.options.ca = rootCas
 }
 

--- a/public/locales/en/testimony.json
+++ b/public/locales/en/testimony.json
@@ -1,75 +1,76 @@
 {
-    "testimonyDetail": {
-        "what": "What",
-        "says": "says",
-        "thisPolicy": "this policy",
-        "edited": "Edited"
-    },
-    "revisionHistory": {
-        "version": "version",
-        "history": "Revision History"
-    },
-    "policyActions": {
-        "actions": "Actions"
-    },
-    "testimonyVersionBanner": {
-        "viewingVersion": "Viewing out of date version of testimony",
-        "backToVersion": "Back to Current Version"
-    },
-    "testimonyCallout": {
-        "bill": "Bill",
-        "position": "{{position1}}"
-    },
-    "testimonyCalloutSection":{
-            "peopleSaying": "What people are saying...",
-            "browseTestimony": "Browse All Testimony"
-    },
-    "reportModal": {
-        "reportTestimony": "Report Testimony",
-        "reason": "Reason",
-        "close": "Close",
-        "reporting": "Reporting",
-        "report": "Report",
-        "rescind": "You may only delete testimony from MAPLE if you made an error in the testimony submission process (e.g., testified on the wrong bill) or if the testimony contains personal information."
-    },
-    "reportToast": {
-        "success": "{{successful1}}"
-    },
-    "sortTestimonyDropDown": {
-        "recentFirst": "Most Recent First",
-        "oldestFirst": "Oldest First"
-    },
-    "testimonyItem": {
-        "deleteTestimonyConfirmation": "Are you sure you want to delete your testimony?",
-        "no": "No",
-        "editIcon": "Edit icon",
-        "deleteIcon": "Delete testimony icon",
-        "expand": "Expand",
-        "moreDetails": "More Details",
-        "edit": "Edit",
-        "rescind": "Rescind",
-        "toast": {
-            "successful": {
-                "header": "Success",
-                "body": "Your report was filed."
-            },
-            "failed": {
-                "header": "Failed",
-                "body": "Your report couldn't be filed. Please try again later."
-            }
-        }
-    },
-    "userFilterDropdown": {
-        "publishedTestimonies": "All Published Testimonies",
-        "usersOnly": "Users Only",
-        "organizationsOnly": "Organizations Only"
-    },
-    "userInfoHeader": {
-        "edited": "Edited"
-    },
-    "viewTestimony": {
-        "showing1": "Showing 1 - ",
-        "outOf": " out of ",
-        "noTestimonies": "There are no testimonies "
+  "testimonyDetail": {
+    "what": "What",
+    "says": "says",
+    "thisPolicy": "this policy",
+    "edited": "Edited"
+  },
+  "revisionHistory": {
+    "version": "version",
+    "history": "Revision History"
+  },
+  "policyActions": {
+    "actions": "Actions"
+  },
+  "testimonyVersionBanner": {
+    "viewingVersion": "Viewing out of date version of testimony",
+    "backToVersion": "Back to Current Version"
+  },
+  "testimonyCallout": {
+    "bill": "Bill",
+    "position": "{{position1}}"
+  },
+  "testimonyCalloutSection": {
+    "peopleSaying": "What people are saying...",
+    "browseTestimony": "Browse All Testimony"
+  },
+  "reportModal": {
+    "reportTestimony": "Report Testimony",
+    "reason": "Reason",
+    "close": "Close",
+    "reporting": "Reporting",
+    "report": "Report",
+    "rescind": "You may only delete testimony from MAPLE if you made an error in the testimony submission process (e.g., testified on the wrong bill) or if the testimony contains personal information."
+  },
+  "reportToast": {
+    "success": "{{successful1}}"
+  },
+  "sortTestimonyDropDown": {
+    "recentFirst": "Most Recent First",
+    "oldestFirst": "Oldest First"
+  },
+  "testimonyItem": {
+    "deleteTestimonyConfirmation": "Are you sure you want to delete your testimony?",
+    "no": "No",
+    "editIcon": "Edit icon",
+    "deleteIcon": "Delete testimony icon",
+    "expand": "Expand",
+    "moreDetails": "More Details",
+    "edit": "Edit",
+    "rescind": "Rescind",
+    "toast": {
+      "successful": {
+        "header": "Success",
+        "body": "Your report was filed."
+      },
+      "failed": {
+        "header": "Failed",
+        "body": "Your report couldn't be filed. Please try again later."
+      }
     }
+  },
+  "userFilterDropdown": {
+    "publishedTestimonies": "All Published Testimonies",
+    "usersOnly": "Users Only",
+    "organizationsOnly": "Organizations Only"
+  },
+  "userInfoHeader": {
+    "edited": "Edited"
+  },
+  "viewTestimony": {
+    "showing": "Showing",
+    "showing1": "Showing 1 - ",
+    "outOf": " out of ",
+    "noTestimonies": "There are no testimonies "
+  }
 }


### PR DESCRIPTION
# Summary
Four small things, in separate commits, combined to one PR for ease 

 - allows top navbar to close when a selection has been chosen 
 - hides upcoming-hearing indictator in browse bills for hearing that is already passed, and shows indicator for upcoming hearings 
 - adds feature flags to hide follow org buttons. also refactors lobbytable hide to use feature flag. 
 - fixes calculations in pagination summary in testimony viewer (on profile pages)
 
# Checklist

- [NA] On the frontend, I've made my strings translate-able.
- [NA] If I've added shared components, I've added a storybook story.
- [NA] I've made pages responsive and look good on mobile.

# Screenshots

view testimony: ![image](https://github.com/codeforboston/maple/assets/30247522/e71a5087-9dd3-400d-ad83-233105c38d18)

# Known issues
none

# Steps to test/reproduce
 - open and close the navbar, open the navbar and select any destination option and it should close as it navigates
 - view bill page and hearing indicators to confirm upcoming and only upcoming hearing are shown
 - view org testimony and profiles and confirm no follow button 
 - view testimony in viewer, double-check my calculations
 