### PR TITLE
Display name bug: adds AuthorName OR conditional to testimony display

### DIFF
--- a/components/TestimonyCard/Author.tsx
+++ b/components/TestimonyCard/Author.tsx
@@ -19,7 +19,7 @@ export const Author = ({ uid, name }: { uid: string; name: string }) => {
           <StyledName href={`/profile?id=${uid}`}>{authorName}</StyledName>
         </h6>
       ) : (
-        <h6>{name}</h6>
+        <h6>{authorName || name}</h6>
       )}
     </div>
   )


### PR DESCRIPTION
# Summary
[issue 1183](https://github.com/codeforboston/maple/issues/1183)
Sets non-link author name option to display non nullish profile name OR name attached to testimony in the nullish case.

# Checklist

- [ ] On the frontend, I've made my strings translate-able.
- [ ] If I've added shared components, I've added a storybook story.
- [ ] I've made pages responsive and look good on mobile.

# Known issues
name from testimony is still present if profile name is somehow blank

# Steps to test/reproduce
For this to truly be considered successful, we must see if this [testimony](https://www.mapletestimony.org/testimony/dmrr0wkKEyxfkH27c3F9i/1) within production is affected, as we are not yet truly sure what caused the bug.