### PR TITLE
Relabel hero header browse button

### DIFF
--- a/components/HeroHeader/HeroHeader.js
+++ b/components/HeroHeader/HeroHeader.js
@@ -79,7 +79,7 @@ const HeroHeader = ({ authenticated }) => {
                     <Wrap href="/bills">
                       <div className={styles.btncontainer}>
                         <Button variant="outline-secondary">
-                          {capitalize(t("browse"))}
+                          {capitalize(t("browse bills"))}
                         </Button>
                       </div>
                     </Wrap>


### PR DESCRIPTION
# Summary

This one liner simply relabels the 'browse' button on the hero header to 'browse bills,' to distinguish it better from the 'browse testimony' button below.

# Checklist

- [ ] On the frontend, I've made my strings translate-able.
- [ ] If I've added shared components, I've added a storybook story.
- [ ] I've made pages responsive and look good on mobile.

# Screenshots

Before:

![image](https://github.com/codeforboston/maple/assets/1727426/880bc710-1fbf-4f62-abb8-6280fc80ce69)

After:

![image](https://github.com/codeforboston/maple/assets/1727426/e10a1b25-b387-4790-9b0f-b295e5b3bde1)


# Known issues


# Steps to test/reproduce

