### PR TITLE
hide rescind testimony button

### DIFF
--- a/components/TestimonyCard/TestimonyItem.tsx
+++ b/components/TestimonyCard/TestimonyItem.tsx
@@ -217,7 +217,7 @@ export const TestimonyItem = ({
 
               {canDelete && (
                 <>
-                  <Col>
+                  {/* <Col>
                     <FooterButton
                       style={{ color: "#c71e32" }}
                       onClick={() => setShowConfirm(s => !s)}
@@ -225,7 +225,7 @@ export const TestimonyItem = ({
                     >
                       {t("testimonyItem.rescind")}
                     </FooterButton>
-                  </Col>
+                  </Col> */}
 
                   {showConfirm && (
                     <ArchiveTestimonyConfirmation
@@ -238,11 +238,11 @@ export const TestimonyItem = ({
               )}
             </>
           )}
-          <Col xs="auto">
+          {/* <Col xs="auto">
             <FooterButton variant="link" onClick={() => setIsReporting(true)}>
               {isUser ? "Request to rescind" : "Report"}
             </FooterButton>
-          </Col>
+          </Col> */}
         </Row>
       </Stack>
 


### PR DESCRIPTION
# Summary

#1234

Remove the "Request to Rescind" text. 

Prior to this PR, it currently shows up whenever you view your own testimony, which is 1) when you view a bill you've added testimony to, 2) when you view your own profile, and 3) when you click 'edit profile' and view the list of your testimonies.

![image](https://media.tenor.com/EKX7SNViuW4AAAAC/revoked-denied.gif)

# Checklist

- [x] On the frontend, I've made my strings translate-able.
- [x] If I've added shared components, I've added a storybook story.
- [x] I've made pages responsive and look good on mobile.

# Screenshots

On Bill Page
![image](https://github.com/codeforboston/maple/assets/73559781/ea078ba4-6bf5-4046-b6b8-6594e5bd79b2)

On View Profile
![image](https://github.com/codeforboston/maple/assets/73559781/8d09f826-9346-455b-aa90-bb9c4588148f)

On Edit Profile
![image](https://github.com/codeforboston/maple/assets/73559781/c7cc5e0f-d03a-4ab1-a325-50dc661edb45)


# Known issues

No known issues

# Steps to test/reproduce

_For each feature or bug fix, create a step by step list for how a reviewer can test it out. E.g.:_

* for each step, make sure "Request to rescind" option is not visible
1. Navigate to a bill that has one's own testimony
2. Navigate to View Profile
3. Naviate to Edit Profile -> Testimonies tab
