### PR TITLE
bill details mobile tweaks

### DIFF
--- a/components/bill/BillDetails.tsx
+++ b/components/bill/BillDetails.tsx
@@ -37,11 +37,11 @@ export const BillDetails = ({ bill }: BillProps) => {
         </Row>
         {bill.history.length > 0 ? (
           <>
-            <Row>
-              <Col>
+            <Row className="align-items-end justify-content-start">
+              <Col md={2}>
                 <BillNumber bill={bill} />
               </Col>
-              <Col xs={6} className="d-flex justify-content-end">
+              <Col xs={10} md={6} className="mb-3 ms-auto">
                 <Status bill={bill} />
               </Col>
             </Row>

--- a/components/bill/SponsorsAndCommittees.tsx
+++ b/components/bill/SponsorsAndCommittees.tsx
@@ -11,6 +11,7 @@ import { BillProps } from "./types"
 import { DisplayUpcomingHearing } from "components/search/bills/BillHit"
 import { dateInFuture } from "components/db/events"
 import { Timestamp } from "firebase/firestore"
+import { useMediaQuery } from "usehooks-ts"
 
 const HearingDate = styled.div`
   font-weight: 500;
@@ -69,6 +70,9 @@ export const Sponsors: FC<BillProps> = ({ bill, className }) => {
   const primary = bill.content?.PrimarySponsor
   const cosponsors = bill.content.Cosponsors.filter(s => s.Id !== primary?.Id)
   const more = cosponsors.length > 2
+  const isMobile = useMediaQuery("(max-width: 768px)")
+
+  const countShowSponsors = isMobile ? 1 : 2
 
   return (
     <LabeledContainer className={className}>
@@ -97,7 +101,7 @@ export const Sponsors: FC<BillProps> = ({ bill, className }) => {
           )}
 
           {bill.content.Cosponsors.filter(s => s.Id !== primary?.Id)
-            .slice(0, 2)
+            .slice(0, countShowSponsors)
             .map(s => (
               <LabeledIcon
                 key={s.Id}

--- a/components/bill/Status.tsx
+++ b/components/bill/Status.tsx
@@ -8,9 +8,8 @@ import { BillProps } from "./types"
 
 const StyledButton = styled(Button)`
   border-radius: 3rem 0 0 3rem;
-  font-size: 2rem;
-  line-height: 2.5rem;
-  height: fit-content;
+  font-size: 1.5rem;
+  line-height: 1.5rem;
   max-width: 100%;
 `
 
@@ -29,7 +28,7 @@ export const Status = ({ bill }: BillProps) => {
       <CourtContext.Provider value={bill.court}>
         <StyledButton
           variant="secondary"
-          className="text-truncate"
+          className="text-truncate ps-4"
           onClick={handleShowBillHistory}
         >
           {history.Action}


### PR DESCRIPTION

# Summary
tweaks status button to show more characters on mobile
tweaks styling to handle browser/mobile differences mostly in higher up components

sets number of cosponsors shown on mobile to 2

resolves #1221

# Checklist

- [NA ] On the frontend, I've made my strings translate-able.
- [ NA] If I've added shared components, I've added a storybook story.
- [X ] I've made pages responsive and look good on mobile.

# Screenshots

bill history button:
![image](https://github.com/codeforboston/maple/assets/30247522/acafa4b6-be8f-435e-a976-086d31990737)
![image](https://github.com/codeforboston/maple/assets/30247522/fa7d0cd7-e5c5-4e04-b3b2-e107c33c5bfe)

cosponsors
![image](https://github.com/codeforboston/maple/assets/30247522/5192cbd7-6640-467b-9ead-0391b0b478af)

_Add some screenshots highlighting your changes._

# Known issues
 this is an older component that uses styled components and should be updated with other tech debt later on.  opted to use the same fontsize on mobile and browser to avoid serverside rendering hang ups in the meantime. 

# Steps to test/reproduce

view bill details page on browser & mobile sizes
