### PR TITLE
adjusted facebook link on profiles

### DIFF
--- a/components/ProfilePage/SocialMediaIcons.tsx
+++ b/components/ProfilePage/SocialMediaIcons.tsx
@@ -40,7 +40,7 @@ export const SocialMediaIcons = ({
 
       {fb && (
         <Col>
-          <External plain href={`${linkedIn}`}>
+          <External plain href={`https://www.facebook.com/${fb}`}>
             <Image alt="facebook" src="/facebook.svg" />
           </External>
         </Col>


### PR DESCRIPTION
# Summary

Fixes the facebook link issue from #1069

PR #1077 added changes to standardize how social media links are stored in the db, but old code remained for the actual link to facebook that was linking to the linkedin value (which if blank defaulted back to the user/org profile)

# Checklist

- [ N/A] On the frontend, I've made my strings translate-able.
- [ N/A] If I've added shared components, I've added a storybook story.
- [ N/A] I've made pages responsive and look good on mobile.

# Screenshots
Prod:
![image](https://github.com/codeforboston/maple/assets/97904016/de7a57d8-2a7d-4c2e-88b2-9416391b7843)

Dev: 
![image](https://github.com/codeforboston/maple/assets/97904016/a9306a12-c20b-4cbf-adde-bd2e6f6b8d37)


# Known issues

The code will append https://www.facebook.com/  with whatever is defined as the fb link in the db. Any orgs/profiles created before PR 1077 may be weird/may need to be manually updated

# Steps to test/reproduce

_For each feature or bug fix, create a step by step list for how a reviewer can test it out. E.g.:_

1. Go to the org profile
2. Hover over/click the link for fb
3. confirm that the link is a valid fb link
