### PR TITLE
flag hide follows and notifications

### DIFF
--- a/components/ProfilePage/ProfileHeader.tsx
+++ b/components/ProfilePage/ProfileHeader.tsx
@@ -13,7 +13,7 @@ import { flags } from "components/featureFlags"
 import { FollowOrgButton } from "components/shared/FollowButton"
 import { useTranslation } from "next-i18next"
 import { Profile } from "../db"
-import { FollowButton } from "./FollowButton"; // TODO: move to /shared
+import { FollowButton } from "./FollowButton" // TODO: move to /shared
 import { OrgContactInfo } from "./OrgContactInfo"
 import { EditProfileButton, MakePublicButton } from "./ProfileButtons"
 
@@ -92,9 +92,7 @@ export const ProfileHeader = ({
                     ) : (
                       <>
                         {flags().followOrg && (
-                          <FollowOrgButton
-                            profileId={profileId}
-                          />
+                          <FollowOrgButton profileId={profileId} />
                         )}
                       </>
                     )}

--- a/components/ProfilePage/ProfileHeader.tsx
+++ b/components/ProfilePage/ProfileHeader.tsx
@@ -1,14 +1,4 @@
-import {
-  collection,
-  deleteDoc,
-  doc,
-  getDocs,
-  query,
-  setDoc,
-  where
-} from "firebase/firestore"
-import { firestore } from "../firebase"
-import { Col, Stack, Row } from "../bootstrap"
+import { Col, Row, Stack } from "../bootstrap"
 import {
   Header,
   OrgIconLarge,
@@ -19,13 +9,13 @@ import {
   UserIconSmall
 } from "./StyledProfileComponents"
 
-import { EditProfileButton, MakePublicButton } from "./ProfileButtons"
-import { OrgContactInfo } from "./OrgContactInfo"
-import { Profile } from "../db"
-import { FollowButton } from "./FollowButton" // TODO: move to /shared
-import { getFunctions, httpsCallable } from "firebase/functions"
-import { useAuth } from "../auth"
+import { flags } from "components/featureFlags"
+import { FollowOrgButton } from "components/shared/FollowButton"
 import { useTranslation } from "next-i18next"
+import { Profile } from "../db"
+import { FollowButton } from "./FollowButton"; // TODO: move to /shared
+import { OrgContactInfo } from "./OrgContactInfo"
+import { EditProfileButton, MakePublicButton } from "./ProfileButtons"
 
 export const ProfileHeader = ({
   isMobile,
@@ -100,11 +90,13 @@ export const ProfileHeader = ({
                         </div>
                       </div>
                     ) : (
-                      <FollowButton
-                        profileId={profileId}
-                        uid={uid}
-                        isMobile={isMobile}
-                      />
+                      <>
+                        {flags().followOrg && (
+                          <FollowOrgButton
+                            profileId={profileId}
+                          />
+                        )}
+                      </>
                     )}
                   </>
                 )}

--- a/components/TestimonyCard/TestimonyItem.tsx
+++ b/components/TestimonyCard/TestimonyItem.tsx
@@ -19,6 +19,7 @@ import styles from "./ViewTestimony.module.css"
 import { UseAsyncReturn } from "react-async-hook"
 import { useTranslation } from "next-i18next"
 import { trimContent } from "components/TestimonyCallout/TestimonyCallout"
+import { flags } from "components/featureFlags"
 
 const FooterButton = styled(Button)`
   margin: 0;
@@ -238,13 +239,7 @@ export const TestimonyItem = ({
               )}
             </>
           )}
-          {/* <Col xs="auto">
-            <FooterButton variant="link" onClick={() => setIsReporting(true)}>
-              {isUser ? "Request to rescind" : "Report"}
-            </FooterButton>
-          </Col> */}
-          {/* rescind hidden. report showing to users other than author */}
-          {!isUser && (
+          {flags().reportTestimony && !isUser && (
             <Col xs="auto">
               <FooterButton variant="link" onClick={() => setIsReporting(true)}>
                 Report

--- a/components/bill/BillDetails.tsx
+++ b/components/bill/BillDetails.tsx
@@ -27,6 +27,7 @@ import { Summary } from "./Summary"
 import { BillProps } from "./types"
 import { useTranslation } from "next-i18next"
 import { isCurrentCourt } from "functions/src/shared"
+import { FollowBillButton } from "components/shared/FollowButton"
 
 const StyledContainer = styled(Container)`
   font-family: "Nunito";
@@ -66,7 +67,7 @@ export const BillDetails = ({ bill }: BillProps) => {
             </Row>
             <Row className="mb-4">
               <Col xs={12} className="d-flex justify-content-end">
-                <FollowButton bill={bill} />
+                {flags().notifications && <FollowBillButton bill={bill} />}
               </Col>
             </Row>
           </>
@@ -77,7 +78,7 @@ export const BillDetails = ({ bill }: BillProps) => {
             </Col>
             <Col xs={6} className="d-flex justify-content-end">
               <Styled>
-                <FollowButton bill={bill} />
+                {flags().notifications && <FollowBillButton bill={bill} />}
               </Styled>
             </Col>
           </Row>
@@ -109,106 +110,5 @@ export const BillDetails = ({ bill }: BillProps) => {
         </Row>
       </StyledContainer>
     </>
-  )
-}
-
-const FollowButton = ({ bill }: BillProps) => {
-  const { t } = useTranslation("common")
-  const billId = bill.id
-  const courtId = bill.court
-  const topicName = `bill-${courtId}-${billId}`
-  const { user } = useAuth()
-  const uid = user?.uid
-  const subscriptionRef = collection(
-    firestore,
-    `/users/${uid}/activeTopicSubscriptions/`
-  )
-
-  const [queryResult, setQueryResult] = useState("")
-  const functions = getFunctions()
-
-  const followBillFunction = httpsCallable(functions, "followBill")
-  const unfollowBillFunction = httpsCallable(functions, "unfollowBill")
-
-  const billQuery = async () => {
-    const q = query(
-      subscriptionRef,
-      where("topicName", "==", `bill-${courtId}-${billId}`)
-    )
-    const querySnapshot = await getDocs(q)
-    querySnapshot.forEach(doc => {
-      // doc.data() is never undefined for query doc snapshots
-      setQueryResult(doc.data().topicName)
-    })
-  }
-
-  useEffect(() => {
-    uid ? billQuery() : null
-  })
-
-  const handleFollowClick = async () => {
-    try {
-      // ensure user is not null
-      if (!user) {
-        throw new Error("User not found")
-      }
-
-      const billLookup = {
-        billId: billId,
-        court: courtId
-      }
-
-      // get token
-      const token = await user.getIdToken()
-
-      // use followBillFunction to follow bill
-      const response = await followBillFunction({ billLookup, token })
-      // handle the response
-      if (response.data) {
-        setQueryResult(topicName)
-      }
-    } catch (error) {
-      console.error(error)
-    }
-  }
-
-  const handleUnfollowClick = async () => {
-    try {
-      // ensure user is not null
-      if (!user) {
-        throw new Error("User not found")
-      }
-
-      const billLookup = {
-        billId: billId,
-        court: courtId
-      }
-
-      // get token
-      const token = await user.getIdToken()
-
-      // use unfollowBillFunction to unfollow bill
-      const response = await unfollowBillFunction({ billLookup, token })
-
-      if (response.data) {
-        setQueryResult("")
-      }
-    } catch (error) {
-      console.error(error)
-    }
-  }
-
-  return (
-    <Button
-      className={`btn btn-primary btn-sm ms-auto py-1 w-auto ${
-        uid ? "" : "visually-hidden"
-      }`}
-      onClick={queryResult ? handleUnfollowClick : handleFollowClick}
-    >
-      {queryResult ? t("button.following") : t("button.follow")}
-      {queryResult ? (
-        <StyledImage src="/check-white.svg" alt={"checkmark"} />
-      ) : null}
-    </Button>
   )
 }

--- a/components/featureFlags.ts
+++ b/components/featureFlags.ts
@@ -10,7 +10,11 @@ export const FeatureFlags = z.object({
   /** Follow button for organizations */
   followOrg: z.boolean().default(false),
   /** Lobbying Table */
-  lobbyingTable: z.boolean().default(false)
+  lobbyingTable: z.boolean().default(false),
+  /** Submitting testimony fron mobile views */
+  mobileTestimony: z.boolean().default(false),
+  /** Report testimony */
+  reportTestimony: z.boolean().default(false)
 })
 
 export type FeatureFlags = z.infer<typeof FeatureFlags>
@@ -28,21 +32,27 @@ const defaults: Record<Env, FeatureFlags> = {
     notifications: true,
     billTracker: true,
     followOrg: true,
-    lobbyingTable: false
+    lobbyingTable: false,
+    mobileTestimony: false,
+    reportTestimony: true
   },
   production: {
     testimonyDiffing: false,
     notifications: false,
     billTracker: false,
     followOrg: false,
-    lobbyingTable: false
+    lobbyingTable: false,
+    mobileTestimony: false,
+    reportTestimony: true
   },
   test: {
     testimonyDiffing: false,
     notifications: false,
     billTracker: false,
     followOrg: false,
-    lobbyingTable: false
+    lobbyingTable: false,
+    mobileTestimony: false,
+    reportTestimony: false
   }
 }
 

--- a/components/search/testimony/TestimonyHit.tsx
+++ b/components/search/testimony/TestimonyHit.tsx
@@ -5,7 +5,7 @@ import { Testimony } from "components/db/testimony"
 import { trimContent } from "components/TestimonyCallout/TestimonyCallout"
 import { formatBillId } from "components/formatting"
 import { useBill } from "components/db/bills"
-import { FollowButton } from "components/shared/FollowButton"
+import { FollowOrgButton } from "components/shared/FollowButton"
 import { Image } from "react-bootstrap"
 import { flags } from "components/featureFlags"
 
@@ -63,7 +63,9 @@ const TestimonyResult = ({ hit }: { hit: Hit<Testimony> }) => {
         <span style={{ flexGrow: 1 }}>
           <b>Written by {writtenBy}</b>
         </span>
-        {isOrg && <FollowButton profileId={hit.authorUid} />}
+        {flags().followOrg && isOrg && (
+          <FollowOrgButton profileId={hit.authorUid} />
+        )}
       </div>
       <hr />
       <div style={{ display: "flex", alignItems: "center" }}>

--- a/components/shared/FollowButton.tsx
+++ b/components/shared/FollowButton.tsx
@@ -31,12 +31,12 @@ export const BaseFollowButton = ({
   }, [uid, topicName, setQueryResult])
 
   const FollowClick = async () => {
-    await followAction() 
+    await followAction()
     setQueryResult(topicName)
   }
 
   const UnfollowClick = async () => {
-    await unfollowAction() 
+    await unfollowAction()
     setQueryResult("")
   }
 

--- a/components/testimony/TestimonyDetailPage/PolicyActions.tsx
+++ b/components/testimony/TestimonyDetailPage/PolicyActions.tsx
@@ -27,7 +27,7 @@ export const PolicyActions: FC<PolicyActionsProps> = ({
   if (flags().notifications)
     items.push(
       <PolicyActionItem
-        onClick={() => window.alert("TODO")}
+        onClick={() => window.alert("TODO")} // TODO: add follow action here
         key="follow"
         billName={`Follow ${billLabel}`}
       />

--- a/pages/bills/[court]/[billId].tsx
+++ b/pages/bills/[court]/[billId].tsx
@@ -40,7 +40,8 @@ export const getServerSideProps: GetServerSideProps = async ctx => {
         "auth",
         "common",
         "footer",
-        "testimony"
+        "testimony",
+        "profile"
       ]))
     }
   }

--- a/pages/testimony/index.tsx
+++ b/pages/testimony/index.tsx
@@ -19,5 +19,6 @@ export const getStaticProps = createGetStaticTranslationProps([
   "auth",
   "common",
   "footer",
-  "testimony"
+  "testimony",
+  "profile"
 ])


### PR DESCRIPTION
# Summary
- adjusting flags to:
  - hide follows and notifications in prod and show in dev
  - show report testimony button in prod 
- imported translation file to connect follow button translation text 
- refactored/combined the follow buttons into a generic base follow button and type-specific wrappers. 


# Checklist

- [x] On the frontend, I've made my strings translate-able.
- [ ] If I've added shared components, I've added a storybook story.
- [ ] I've made pages responsive and look good on mobile.

# Screenshots


# Known issues

The PolicyAction for bill following, seen on the testimony item page in the a sidebar, is not yet hooked up to the follow logic & was out of scope

# Steps to test/reproduce
N/A