### PR TITLE
Feature/disable mobile testimony

### DIFF
--- a/components/TestimonyCard/TestimonyItem.tsx
+++ b/components/TestimonyCard/TestimonyItem.tsx
@@ -123,8 +123,9 @@ export const TestimonyItem = ({
       <div className={`border-0 h5 d-flex`}>
         {isMobile && isUser && (
           <>
+            {/* removes mobile view until is ready at a later stage */}
             <Internal
-              className={styles.link}
+              className={`${styles.link}, visually-hidden`}
               href={formUrl(testimony.billId, testimony.court)}
             >
               <Image

--- a/components/TestimonyCard/TestimonyItem.tsx
+++ b/components/TestimonyCard/TestimonyItem.tsx
@@ -201,7 +201,7 @@ export const TestimonyItem = ({
               <ViewAttachment testimony={testimony} />
             </FooterButton>
           </Col>
-
+          {/* removes mobile view until edit testimony is ready at a later stage */}
           {isUser && !isMobile && (
             <>
               {onProfilePage && (
@@ -219,6 +219,7 @@ export const TestimonyItem = ({
 
               {canDelete && (
                 <>
+                  {/* removed until delete is ready at a later stage */}
                   {/* <Col>
                     <FooterButton
                       style={{ color: "#c71e32" }}

--- a/components/bill/BillDetails.tsx
+++ b/components/bill/BillDetails.tsx
@@ -11,6 +11,7 @@ import {
 import { getFunctions, httpsCallable } from "firebase/functions"
 import { useEffect, useState } from "react"
 import styled from "styled-components"
+import { useMediaQuery } from "usehooks-ts"
 import { useAuth } from "../auth"
 import { Button, Col, Container, Image, Row } from "../bootstrap"
 import { firestore } from "../firebase"
@@ -28,6 +29,7 @@ import { BillProps } from "./types"
 import { useTranslation } from "next-i18next"
 import { isCurrentCourt } from "functions/src/shared"
 import { FollowBillButton } from "components/shared/FollowButton"
+import { Notice } from "../shared/Notice"
 
 const StyledContainer = styled(Container)`
   font-family: "Nunito";
@@ -42,6 +44,7 @@ const StyledImage = styled(Image)`
 
 export const BillDetails = ({ bill }: BillProps) => {
   const { t } = useTranslation("common")
+  const isMobile = useMediaQuery("(max-width: 768px)")
   return (
     <>
       {!isCurrentCourt(bill.court) && (
@@ -91,6 +94,12 @@ export const BillDetails = ({ bill }: BillProps) => {
         <Row>
           <Col md={8}>
             <Sponsors bill={bill} className="mt-4 pb-1" />
+            {isMobile && (
+              <Notice
+                text="Currently, providing testimony is only available in the Desktop version of MAPLE"
+                className="mt-4"
+              />
+            )}
             <BillTestimonies bill={bill} className="mt-4" />
             {flags().lobbyingTable && (
               <LobbyingTable bill={bill} className="mt-4 pb-1" />

--- a/components/publish/panel/YourTestimony.tsx
+++ b/components/publish/panel/YourTestimony.tsx
@@ -1,5 +1,6 @@
 import { hasDraftChanged } from "components/db"
 import { useState } from "react"
+import { useMediaQuery } from "usehooks-ts"
 import styled from "styled-components"
 import { Button, Stack } from "../../bootstrap"
 import { External, twitterShareLink, Wrap } from "../../links"
@@ -25,17 +26,24 @@ const MainPanel = styled(({ ...rest }) => {
   const unpublishedDraft = hasDraftChanged(draft, publication)
   const [showConfirm, setShowConfirm] = useState(false)
   const bill = usePublishState().bill!
+  const isMobile = useMediaQuery("(max-width: 768px)")
 
   return (
     <div {...rest}>
       <div className="d-flex">
         <span className="title">Your Testimony</span>
-        <EditTestimonyButton
-          className="me-1"
-          billId={bill.id}
-          court={bill.court}
-        />
-        <ArchiveTestimonyButton onClick={() => setShowConfirm(s => !s)} />
+        {/* removes mobile view until ready at a later stage */}
+        {!isMobile && (
+          <>
+            {" "}
+            <EditTestimonyButton
+              className="me-1"
+              billId={bill.id}
+              court={bill.court}
+            />
+            <ArchiveTestimonyButton onClick={() => setShowConfirm(s => !s)} />
+          </>
+        )}
       </div>
       <ArchiveTestimonyConfirmation
         className="mt-2"

--- a/components/shared/Notice.tsx
+++ b/components/shared/Notice.tsx
@@ -1,0 +1,15 @@
+import styled from "styled-components"
+import { Card as MapleCard } from "../Card/Card"
+
+export const Notice = (props: { text: string; className: string }) => {
+  var body = <NoticeStyle>{props.text}</NoticeStyle>
+  return <MapleCard body={body} className={props.className} />
+}
+const NoticeStyle = styled.div`
+  padding: 1rem;
+  font-size: 1.2rem;
+  text-align: center;
+  font-family: nunito;
+  background-color: #1a3185;
+  color: white;
+`

--- a/components/testimony/TestimonyDetailPage/TestimonyDetailPage.tsx
+++ b/components/testimony/TestimonyDetailPage/TestimonyDetailPage.tsx
@@ -28,6 +28,7 @@ export const TestimonyDetailPage: FC = () => {
           </Col>
 
           <Col md={4}>
+            {/* removes mobile view until ready at a later stage */}
             {!isMobile && <PolicyActions className="mb-4" isUser={isUser} />}
             <RevisionHistory />
           </Col>


### PR DESCRIPTION
Mobile friendly buttons have now been removed from several files as well as a rescind button that was missed. Short comments have been left to more easily find code in the future. I commented out the rescind/delete buttons instead of hiding them.

https://github.com/codeforboston/maple/issues/1239
