### PR TITLE
Fix to #1275

### DIFF
--- a/pages/submit-testimony.tsx
+++ b/pages/submit-testimony.tsx
@@ -25,5 +25,6 @@ export const getStaticProps = createGetStaticTranslationProps([
   "auth",
   "common",
   "footer",
-  "testimony"
+  "testimony",
+  "editProfile"
 ])


### PR DESCRIPTION
# Summary

Resolves #1275
added editProfile.json to submit-testimony page allow access to translations for legislators. 

# Checklist

- [x] On the frontend, I've made my strings translate-able.
- [N/A ] If I've added shared components, I've added a storybook story.
- [ N/A] I've made pages responsive and look good on mobile.

# Screenshots
![image](https://github.com/codeforboston/maple/assets/97904016/6e258022-d093-430d-ac81-46264e0bbae9)


# Known issues
May possibly want to move these items to common.json, but this is the quickest fix without having to adjust other files as well.

# Steps to test/reproduce

Go to Submit new testimony on a profile that does not have legislators defined. Confirm that the text is translated and not using the translation keywords for rep and senator.
