### PR TITLE
changes conditional to find correct scenario

### DIFF
--- a/components/TestimonyCard/ViewTestimony.tsx
+++ b/components/TestimonyCard/ViewTestimony.tsx
@@ -140,7 +140,7 @@ const ViewTestimony = (
                     />
                   ))}
 
-                {testimony.length > 10 && (
+                {(pagination.hasPreviousPage || pagination.hasNextPage) && (
                   <PaginationButtons pagination={pagination} />
                 )}
               </div>


### PR DESCRIPTION
I've changed the conditional that would make pagination buttons appear from "testimony.length > 10" to "(pagination.hasPreviousPage || pagination.hasNextPage)". 

testimony.length checks the size of the current list of testimony items which would always be 10 or less. The built in hasPreviousPage and pagination.hasNextPage are a better choice for conditional.

A bug that is possibly only in dev due to many test testimony, may be causing an additional issue with this iteration of pagination.
There is a case where the testimony count and actual visible testimony are not the same. When testimony count is greater than actual  amount of pullable testimony, pagination can cause nextKey to be clickable when there should be no next page, bringing the user to an empty field for testimony while also breaking pagination as it finds no list of testimony to refer back to.