### PR TITLE
Following Bill - URL Bug

### DIFF
--- a/components/EditProfilePage/FollowingTab.tsx
+++ b/components/EditProfilePage/FollowingTab.tsx
@@ -277,7 +277,7 @@ function FollowedItem({
                   className="mr-4 mt-0 mb-0 ms-0"
                   src={profile?.profileImage}
                 />
-                <Internal href={`organizations/${element?.profileId}`}>
+                <Internal href={`profile?id=${element?.profileId}`}>
                   {fullName}
                 </Internal>
               </Col>

--- a/components/EditProfilePage/FollowingTab.tsx
+++ b/components/EditProfilePage/FollowingTab.tsx
@@ -247,11 +247,9 @@ function FollowedItem({
     <Styled>
       {type === "bill" ? (
         <>
-          <StyledHeader
-            href={`https://malegislature.gov/Bills/${element?.court}/${element?.billId}`}
-          >
+          <Internal href={`bills/${element?.court}/${element?.billId}`}>
             {formatBillId(element?.billId)}
-          </StyledHeader>
+          </Internal>
 
           <Row>
             <Col xs={9}>

--- a/components/EditProfilePage/FollowingTab.tsx
+++ b/components/EditProfilePage/FollowingTab.tsx
@@ -247,11 +247,10 @@ function FollowedItem({
     <Styled>
       {type === "bill" ? (
         <>
-          <Internal href={`bills/${element?.court}/${element?.billId}`}>
-            {formatBillId(element?.billId)}
-          </Internal>
-
-          <Row>
+          <Row className={`align-items-center`}>
+            <Internal href={`bills/${element?.court}/${element?.billId}`}>
+              {formatBillId(element?.billId)}
+            </Internal>
             <Col xs={9}>
               <BillFollowingTitle court={element?.court} id={element?.billId} />
             </Col>


### PR DESCRIPTION
# Summary
#1286 

- Fixed the url for followed Bills to reference the MAPLE's website Bill instead of the Legislature's.
- Made some small code refactor so that the components for both organizations and bills use the same code
- Modified the URL for the organization to correctly link the organization using the profile?id= prefix.


# Checklist

- [ ] On the frontend, I've made my strings translate-able.
- [ ] If I've added shared components, I've added a storybook story.
- [ ] I've made pages responsive and look good on mobile.

# Screenshots

https://github.com/codeforboston/maple/assets/55262612/58ae57b2-87cb-4b80-a3f1-bbbb2e20a008



# Known issues

Currently, we navigate to the organization by using profile?id= as the prefix, but should we aim to have organizations as the prefix instead?

# Steps to test/reproduce

1. Go to the edit profile
2. Click on following
3. Click on the hyperlinks for either the bills or the organizations.
