### PR TITLE
adds a role check before allowing user to post testimony

### DIFF
--- a/functions/src/common.ts
+++ b/functions/src/common.ts
@@ -67,6 +67,19 @@ export function checkAdmin(context: https.CallableContext) {
     throw fail("permission-denied", "You must be an admin")
   }
 }
+/**
+ * Checks caller's role. Must not be a role that is pending verification/upgrade
+ */
+export function checkRoleVerified(context: https.CallableContext) {
+  const callerRole = context.auth?.token.role
+  console.log(callerRole)
+  if (!["organization", "user", "admin"].includes(callerRole)) {
+    throw fail(
+      "permission-denied",
+      `You must have a verified account type to perform this action.`
+    )
+  }
+}
 
 /** Constructs a new HTTPS error */
 export function fail(code: https.FunctionsErrorCode, message: string) {

--- a/functions/src/testimony/publishTestimony.ts
+++ b/functions/src/testimony/publishTestimony.ts
@@ -3,7 +3,14 @@ import { https, logger } from "firebase-functions"
 import { nanoid } from "nanoid"
 import { Record } from "runtypes"
 import { Bill } from "../bills/types"
-import { checkAuth, checkRequest, checkRoleVerified, DocUpdate, fail, Id } from "../common"
+import {
+  checkAuth,
+  checkRequest,
+  checkRoleVerified,
+  DocUpdate,
+  fail,
+  Id
+} from "../common"
 import { db, FieldValue, Timestamp } from "../firebase"
 import { supportedGeneralCourts } from "../shared"
 import { Attachments, PublishedAttachmentState } from "./attachments"
@@ -24,7 +31,7 @@ export const publishTestimony = https.onCall(async (data, context) => {
   const { draftId } = checkRequest(PublishTestimonyRequest, data)
 
   checkRoleVerified(context)
-  
+
   let output: TransactionOutput
   try {
     output = await db.runTransaction(t =>

--- a/functions/src/testimony/publishTestimony.ts
+++ b/functions/src/testimony/publishTestimony.ts
@@ -3,7 +3,7 @@ import { https, logger } from "firebase-functions"
 import { nanoid } from "nanoid"
 import { Record } from "runtypes"
 import { Bill } from "../bills/types"
-import { checkAuth, checkRequest, DocUpdate, fail, Id } from "../common"
+import { checkAuth, checkRequest, checkRoleVerified, DocUpdate, fail, Id } from "../common"
 import { db, FieldValue, Timestamp } from "../firebase"
 import { supportedGeneralCourts } from "../shared"
 import { Attachments, PublishedAttachmentState } from "./attachments"
@@ -23,6 +23,8 @@ export const publishTestimony = https.onCall(async (data, context) => {
   const uid = checkAuth(context, checkEmailVerification)
   const { draftId } = checkRequest(PublishTestimonyRequest, data)
 
+  checkRoleVerified(context)
+  
   let output: TransactionOutput
   try {
     output = await db.runTransaction(t =>

--- a/tests/integration/testimony.test.ts
+++ b/tests/integration/testimony.test.ts
@@ -208,9 +208,12 @@ describe.only("publishTestimony", () => {
 
     // sign in as created user to run the test
     await signInUser(newPendingOrg.email)
-    const { draftId: deletableDraftId } = await createDraft(newPendingOrg.uid, billId)
+    const { draftId: deletableDraftId } = await createDraft(
+      newPendingOrg.uid,
+      billId
+    )
     expect(await publishTestimony({ draftId: deletableDraftId })).toBeDefined()
-  }) 
+  })
 
   it("Publishes testimony on scraped bills", async () => {
     const { draftId } = await createDraft(uid, "H1", 192)


### PR DESCRIPTION
# Summary
adds a role check before allowing user to post testimony
pendingUpgrade role cannot post testimony
verified org can post testimony
added tests for same

this is the backend part of issue #1171 

# Why is this a draft
Without the front end elements explaining why they can't post, I think users could have a very frustrating and negative experience. I think we should make a feature branch on the shared repo and merge into main only when all the elements are there. 

# Known issues
 - needs frontend elements: user information, disable buttons, user feedback info like toasts or popups if they attempt to interact with the posting page


note: publishTestimony calls on firebase functions, so firebase error messages are used instead of https status code

