### PR TITLE
fixes placement of bill status on bill detail page

### DIFF
--- a/components/bill/BillDetails.tsx
+++ b/components/bill/BillDetails.tsx
@@ -61,7 +61,11 @@ export const BillDetails = ({ bill }: BillProps) => {
               <Col md={2}>
                 <BillNumber bill={bill} />
               </Col>
-              <Col xs={10} md={6} className="mb-3 ms-auto d-flex justify-content-end">
+              <Col
+                xs={10}
+                md={6}
+                className="mb-3 ms-auto d-flex justify-content-end"
+              >
                 <Status bill={bill} />
               </Col>
             </Row>

--- a/components/bill/BillDetails.tsx
+++ b/components/bill/BillDetails.tsx
@@ -61,7 +61,7 @@ export const BillDetails = ({ bill }: BillProps) => {
               <Col md={2}>
                 <BillNumber bill={bill} />
               </Col>
-              <Col xs={10} md={6} className="mb-3 ms-auto justify-content-end">
+              <Col xs={10} md={6} className="mb-3 ms-auto d-flex justify-content-end">
                 <Status bill={bill} />
               </Col>
             </Row>

--- a/components/bill/BillDetails.tsx
+++ b/components/bill/BillDetails.tsx
@@ -61,7 +61,7 @@ export const BillDetails = ({ bill }: BillProps) => {
               <Col md={2}>
                 <BillNumber bill={bill} />
               </Col>
-              <Col xs={10} md={6} className="mb-3 ms-auto">
+              <Col xs={10} md={6} className="mb-3 ms-auto justify-content-end">
                 <Status bill={bill} />
               </Col>
             </Row>

--- a/components/bill/Status.tsx
+++ b/components/bill/Status.tsx
@@ -10,7 +10,8 @@ const StyledButton = styled(Button)`
   border-radius: 3rem 0 0 3rem;
   font-size: 1.5rem;
   line-height: 1.5rem;
-  max-width: 100%;
+  max-width: fit-content;
+  flex: 1;
 `
 
 export const CourtContext = createContext(1)


### PR DESCRIPTION

# Summary
fixes placement of bill status on bill detail page when history action is very short

# Screenshots
before: 
![image](https://github.com/codeforboston/maple/assets/30247522/7d513240-b8cd-4f30-b1ef-c1184909233f)

after: 
![image](https://github.com/codeforboston/maple/assets/30247522/7ee37cad-52f2-4316-bb80-edbf40264a9c)

