### PR TITLE
editProfile page load error fix

### DIFF
--- a/components/TestimonyCard/TestimonyItem.tsx
+++ b/components/TestimonyCard/TestimonyItem.tsx
@@ -102,7 +102,9 @@ export const TestimonyItem = ({
   const reportMutation = useReportTestimony()
   const didReport = reportMutation.isError || reportMutation.isSuccess
 
-  const testimonyContent = testimony.content ?? 'This draft has no content. Click Edit to add your testimony.'
+  const testimonyContent =
+    testimony.content ??
+    "This draft has no content. Click Edit to add your testimony."
 
   const snippetChars = 500
   const [showAllTestimony, setShowAllTestimony] = useState(false)

--- a/components/TestimonyCard/TestimonyItem.tsx
+++ b/components/TestimonyCard/TestimonyItem.tsx
@@ -102,7 +102,7 @@ export const TestimonyItem = ({
   const reportMutation = useReportTestimony()
   const didReport = reportMutation.isError || reportMutation.isSuccess
 
-  const testimonyContent = testimony.content
+  const testimonyContent = testimony.content ?? 'This draft has no content. Click Edit to add your testimony.'
 
   const snippetChars = 500
   const [showAllTestimony, setShowAllTestimony] = useState(false)
@@ -183,24 +183,25 @@ export const TestimonyItem = ({
               </FooterButton>
             </Col>
           )}
-
-          <Col>
-            <FooterButton variant="link">
-              <Internal
-                className={styles.link}
-                href={maple.testimony({ publishedId: testimony.id })}
-              >
-                {t("testimonyItem.moreDetails")}
-              </Internal>
-            </FooterButton>
-          </Col>
-
-          <Col className="justify-content-end d-flex">
-            <FooterButton variant="link">
-              <ViewAttachment testimony={testimony} />
-            </FooterButton>
-          </Col>
-
+          {testimony.id && (
+            <Col>
+              <FooterButton variant="link">
+                <Internal
+                  className={styles.link}
+                  href={maple.testimony({ publishedId: testimony.id })}
+                >
+                  {t("testimonyItem.moreDetails")}
+                </Internal>
+              </FooterButton>
+            </Col>
+          )}
+          {testimony.attachmentId && (
+            <Col className="d-flex">
+              <FooterButton variant="link">
+                <ViewAttachment testimony={testimony} />
+              </FooterButton>
+            </Col>
+          )}
           {isUser && !isMobile && (
             <>
               {onProfilePage && (
@@ -239,6 +240,7 @@ export const TestimonyItem = ({
               )}
             </>
           )}
+          {/* report */}
           {flags().reportTestimony && !isUser && (
             <Col xs="auto">
               <FooterButton variant="link" onClick={() => setIsReporting(true)}>


### PR DESCRIPTION
# Summary
Adds default string in case testimony.content is undefined to stop editProfile page loading error.

adds conditional for rendering more details (testimony.id) and view attachment (testimony.attachmentId) buttons to prevent navigating to non-existent pages

addresses #1185 

# Known issues

This allows the page to load but we should put a little more thought into where we address this error, and the ui changes/copy involved

# Steps to test/reproduce

1. go to a bill 
1. create testimony
1. go through the flow to the page with the composition box. don't enter anything in the box. 
1. navigate to your edit profile page, testimony tab.  without this fix, it should throw an error. with it, the page should load
