### PR TITLE
Bug: Delete Testimony; comments out delete testimony button and confirmation dropdown

### DIFF
--- a/components/publish/panel/YourTestimony.tsx
+++ b/components/publish/panel/YourTestimony.tsx
@@ -35,14 +35,16 @@ const MainPanel = styled(({ ...rest }) => {
           billId={bill.id}
           court={bill.court}
         />
-        <ArchiveTestimonyButton onClick={() => setShowConfirm(s => !s)} />
+        {/*Delete testimony removed until ready */}
+        {/* <ArchiveTestimonyButton onClick={() => setShowConfirm(s => !s)} /> */}
       </div>
-      <ArchiveTestimonyConfirmation
+      {/*Delete testimony confirmation-dropdown removed until ready */}
+      {/* <ArchiveTestimonyConfirmation
         className="mt-2"
         show={showConfirm}
         onHide={() => setShowConfirm(false)}
         archiveTestimony={deleteTestimony}
-      />
+      /> */}
       <div className="divider mt-3 mb-3" />
       <TestimonyPreview type="draft" className="mb-2" />
       {unpublishedDraft && <div className="draft-badge">Draft</div>}


### PR DESCRIPTION
Quick fix to remove appearance of delete functionality. This fix comments out the delete button and confirmation accordion code fromcomponents/publish/panel/YourTestimony.tsx which is present in more than one page.

[issue](https://github.com/codeforboston/maple/issues/1302)