### PR TITLE
fix : Adjust Org Name in Edit Profile

### DIFF
--- a/components/EditProfilePage/PersonalInfoTab.tsx
+++ b/components/EditProfilePage/PersonalInfoTab.tsx
@@ -112,9 +112,11 @@ export function PersonalInfoTab({
           <h4 className="mb-3">{t("forms.generalInfo")}</h4>
           <Row>
             <Input
-              label={t("forms.fullName")}
+              label={t(isOrg ? "forms.orgName" : "forms.fullName")}
               {...register("fullName", {
-                required: t("forms.errNameRequired").toString()
+                required: t(
+                  isOrg ? "forms.errOrgNameRequired" : "forms.errNameRequired"
+                ).toString()
               })}
               className="w-100"
               defaultValue={fullName}

--- a/public/locales/en/editProfile.json
+++ b/public/locales/en/editProfile.json
@@ -46,10 +46,12 @@
     "forms": {
         "generalInfo": "General Information",
         "fullName": "Full Name",
+        "orgName" : "Organization Name",
         "nickname": "Nickname",
         "makePublic": "Make Public",
         "makePrivate": "Make Private",
         "errNameRequired": "Name is required",
+        "errOrgNameRequired" : "Organization Name is required",
         "aboutYou": "Write something about yourself",
         "aboutYouTip":"What should you write?",
         "selectOrgCategory": "Select an organization cateogry",


### PR DESCRIPTION
# Summary

close#1316

Updated the Personelnfo tab to conditionally render the input field label and error text. 

# Checklist

- [ x] On the frontend, I've made my strings translate-able.
-  [ ] If I've added shared components, I've added a storybook story.
- [ ] I've made pages responsive and look good on mobile.


