### PR TITLE
Copy recipients bug

### DIFF
--- a/components/buttons.tsx
+++ b/components/buttons.tsx
@@ -122,8 +122,13 @@ export const CopyButton = ({
   text,
   tooltipDurationMs = 1000,
   children,
+  format = "text/html",
   ...props
-}: ButtonProps & { text: string; tooltipDurationMs?: number }) => {
+}: ButtonProps & {
+  text: string
+  tooltipDurationMs?: number
+  format?: string
+}) => {
   const [show, setShow] = useState(false)
   const target = useRef(null)
   const closeTimeout = useRef<any>()
@@ -131,7 +136,7 @@ export const CopyButton = ({
     <>
       <CopyToClipboard
         text={text}
-        options={{ format: "text/html" }}
+        options={{ format: format }}
         onCopy={(_, success) => {
           if (success) {
             clearTimeout(closeTimeout.current)

--- a/components/publish/SelectRecipients.tsx
+++ b/components/publish/SelectRecipients.tsx
@@ -110,6 +110,7 @@ const RecipientControls = styled(({ className }) => {
         variant="outline-secondary"
         text={email.to}
         className="copy"
+        format="text/plain"
       >
         <FontAwesomeIcon icon={faCopy} /> Copy Email Recipients
       </CopyButton>

--- a/components/publish/hooks/useTestimonyEmail.ts
+++ b/components/publish/hooks/useTestimonyEmail.ts
@@ -11,11 +11,12 @@ export const useTestimonyEmail = () => {
   const { profile } = useProfile()
 
   const to = share.recipients
-    .map(r => r.EmailAddress)
-    .join(","),
+      .map(r => `${r.Name} <${r.EmailAddress}>`)
+      .join(","),
     billId = formatBillId(bill?.id!),
-    intro = `As your constituent, I am writing to let you know that I ${positionActions[position!]
-      } bill ${billId}: "${bill?.content.Title.trim()}".`,
+    intro = `As your constituent, I am writing to let you know that I ${
+      positionActions[position!]
+    } bill ${billId}: "${bill?.content.Title.trim()}".`,
     testimonyUrl =
       authorUid &&
       bill &&

--- a/components/publish/hooks/useTestimonyEmail.ts
+++ b/components/publish/hooks/useTestimonyEmail.ts
@@ -11,12 +11,11 @@ export const useTestimonyEmail = () => {
   const { profile } = useProfile()
 
   const to = share.recipients
-      .map(r => `${r.Name} <${r.EmailAddress}>`)
-      .join(","),
+    .map(r => r.EmailAddress)
+    .join(","),
     billId = formatBillId(bill?.id!),
-    intro = `As your constituent, I am writing to let you know that I ${
-      positionActions[position!]
-    } bill ${billId}: "${bill?.content.Title.trim()}".`,
+    intro = `As your constituent, I am writing to let you know that I ${positionActions[position!]
+      } bill ${billId}: "${bill?.content.Title.trim()}".`,
     testimonyUrl =
       authorUid &&
       bill &&


### PR DESCRIPTION
# Summary

#1291 
- Updated the CopyButton component so that the recipients can be copied as Plain Text instead of HTML, which allows for it to be formatted and pasted properly in the email.

# Checklist

- [ ] On the frontend, I've made my strings translate-able.
- [ ] If I've added shared components, I've added a storybook story.
- [ ] I've made pages responsive and look good on mobile.

# Screenshots


https://github.com/codeforboston/maple/assets/55262612/09a2cece-b617-4a19-bc35-fd200e38fee4



# Known issues

_If you've run against limitations or caveats, include them here. Include follow-up issues as well._

# Steps to test/reproduce

1. Create a testimony
2. Click on email recipients
3. Paste it anywhere to check if the email is included with the names.
