### PR TITLE
Browse testimony button styling

### DIFF
--- a/components/search/SortBy.tsx
+++ b/components/search/SortBy.tsx
@@ -39,6 +39,15 @@ const StyledSelect = styled(Select)`
     cursor: pointer;
   }
 
+  .s__option--is-selected {
+    background-color: transparent;
+    color: black;
+  }
+
+  .s__option--is-selected:hover {
+    background-color: #deebff;
+  }
+
   .s__single-value,
   .s__indicator {
     color: white;

--- a/components/search/SortBy.tsx
+++ b/components/search/SortBy.tsx
@@ -33,6 +33,7 @@ const StyledSelect = styled(Select)`
   .s__control {
     background-color: var(--bs-blue);
     border: none;
+    box-shadow: none;
     min-height: 1rem;
     line-height: 1rem;
     cursor: pointer;


### PR DESCRIPTION
# Summary

#1314 
- Added CSS to mimic the hover and background color of the other options in the dropdown. Also removed box-shadow from the dropdown to get rid of the light-blue outline.

# Checklist

- [ ] On the frontend, I've made my strings translate-able.
- [ ] If I've added shared components, I've added a storybook story.
- [ ] I've made pages responsive and look good on mobile.

# Screenshots


https://github.com/codeforboston/maple/assets/55262612/321443b7-7553-46c6-b9c8-8fc56d5fb777



# Known issues


# Steps to test/reproduce

1. Go to browse testimony
2. Click on the sort filter and hover over the different options
