### PR TITLE
tweak bill info on publishs page

### DIFF
--- a/components/publish/QuickInfo.tsx
+++ b/components/publish/QuickInfo.tsx
@@ -14,7 +14,9 @@ export function QuickInfo({ bill, profile }: { bill: Bill; profile: Profile }) {
   return (
     <InfoContainer>
       <Label>You're writing testimony about</Label>
-      <Chip className="brown">{Title} (bill {bill})</Chip>
+      <Chip className="brown">
+        {Title} (bill {bill})
+      </Chip>
       {city && (
         <>
           <Label>in</Label>

--- a/components/publish/QuickInfo.tsx
+++ b/components/publish/QuickInfo.tsx
@@ -13,8 +13,8 @@ export function QuickInfo({ bill, profile }: { bill: Bill; profile: Profile }) {
     hasLegislators = Boolean(representative || senator)
   return (
     <InfoContainer>
-      <Label>You're writing a testimony about</Label>
-      <Chip className="brown">{Title}</Chip>
+      <Label>You're writing testimony about</Label>
+      <Chip className="brown">{Title} (bill {bill})</Chip>
       {city && (
         <>
           <Label>in</Label>

--- a/components/publish/QuickInfo.tsx
+++ b/components/publish/QuickInfo.tsx
@@ -15,7 +15,8 @@ export function QuickInfo({ bill, profile }: { bill: Bill; profile: Profile }) {
     <InfoContainer>
       <Label>You're writing testimony about</Label>
       <Chip className="brown">
-        {Title} (bill {bill})
+        {Title}
+        (bill {bill.id})
       </Chip>
       {city && (
         <>

--- a/components/publish/QuickInfo.tsx
+++ b/components/publish/QuickInfo.tsx
@@ -15,8 +15,7 @@ export function QuickInfo({ bill, profile }: { bill: Bill; profile: Profile }) {
     <InfoContainer>
       <Label>You're writing testimony about</Label>
       <Chip className="brown">
-        {Title}
-        (bill {bill.id})
+        {Title}&nbsp;(Bill {bill.id})
       </Chip>
       {city && (
         <>

--- a/components/publish/SubmitTestimonyForm.tsx
+++ b/components/publish/SubmitTestimonyForm.tsx
@@ -82,7 +82,7 @@ const Form = ({
         href={links.maple.bill(bill)}
         className={clsx(!synced && "pe-none")}
       >
-        Back to Bill (Bill :{bill.id})
+        Back to Bill (Bill {bill.id})
       </links.Internal>
       <Overview className="mt-3" />
       <ProgressBar className="mt-4 mb-4" currentStep={step} />

--- a/components/publish/SubmitTestimonyForm.tsx
+++ b/components/publish/SubmitTestimonyForm.tsx
@@ -81,7 +81,7 @@ const Form = ({
         href={links.maple.bill(bill)}
         className={clsx(!synced && "pe-none")}
       >
-        Back to Bill
+        Back to Bill (Bill {bill})
       </links.Internal>
       <Overview className="mt-3" />
       <ProgressBar className="mt-4 mb-4" currentStep={step} />
@@ -97,7 +97,7 @@ const Overview = ({ className }: { className: string }) => (
       <Divider className="me-5" />
       <div className="mt-2">
         Let your voice be heard! MAPLE gives users the ability to send their
-        unfiltered feedback on bills to legislators, comittees, and other
+        unfiltered feedback on bills to legislators, committees, and other
         relevant parties. <b>Writing testimony is as easy as 1-2-3!</b>
       </div>
     </div>

--- a/components/publish/SubmitTestimonyForm.tsx
+++ b/components/publish/SubmitTestimonyForm.tsx
@@ -75,13 +75,14 @@ const Form = ({
     publish: <PublishTestimony />,
     share: <ShareTestimony />
   }
+
   return (
     <FormContainer>
       <links.Internal
         href={links.maple.bill(bill)}
         className={clsx(!synced && "pe-none")}
       >
-        Back to Bill (Bill {bill})
+        Back to Bill (Bill :{bill.id})
       </links.Internal>
       <Overview className="mt-3" />
       <ProgressBar className="mt-4 mb-4" currentStep={step} />


### PR DESCRIPTION
# Summary

A user pointed out that our publish testimony page does not currently display the bill number. This small PR simply adds it and makes some other small typographical changes to this page.

# Checklist

- [ ] On the frontend, I've made my strings translate-able.
- [ ] If I've added shared components, I've added a storybook story.
- [ ] I've made pages responsive and look good on mobile.

# Screenshots

Original version:
![image](https://github.com/codeforboston/maple/assets/1727426/c0eac0ef-b0c5-4ad5-8f43-e0dc4b202032)


# Known issues

_If you've run against limitations or caveats, include them here. Include follow-up issues as well._

# Steps to test/reproduce

