### PR TITLE
FAQ Following Adjustment

### DIFF
--- a/components/Faq/FaqCard.tsx
+++ b/components/Faq/FaqCard.tsx
@@ -4,7 +4,7 @@ import styles from "./faq.module.css"
 
 type faqCardProps = {
   heading: string
-  qAndAs: { question: string; answer: string }[]
+  qAndAs: { disabled?: boolean; question: string; answer: string }[]
 }
 
 export const FaqCard = ({ heading, qAndAs }: faqCardProps) => {
@@ -12,15 +12,18 @@ export const FaqCard = ({ heading, qAndAs }: faqCardProps) => {
     <Card className={styles.faqCard}>
       <h2>{heading ?? ""}</h2>
       <hr></hr>
-      {qAndAs.map((key, index) => (
-        <div className={styles.faqQA} key={index}>
-          <FaqQandA
-            key={index}
-            question={key.question}
-            answer={key.answer}
-          ></FaqQandA>
-        </div>
-      ))}
+      {qAndAs.map(
+        (key, index) =>
+          typeof key.disabled === "undefined" && (
+            <div className={styles.faqQA} key={index}>
+              <FaqQandA
+                key={index}
+                question={key.question}
+                answer={key.answer}
+              ></FaqQandA>
+            </div>
+          )
+      )}
     </Card>
   )
 }

--- a/components/Faq/faqContent.json
+++ b/components/Faq/faqContent.json
@@ -15,6 +15,8 @@
         "answer": "People generally congregate online in for-profit spaces (e.g., Twitter or Facebook) which are designed to maximize clicks and generate profit. That is well and good for entertainment, but they are poor mechanisms for political energy. MAPLE is designed to maintain civility, promote meaningful engagement, and to channel the knowledge and aspirations of the electorate to our elected representatives."
       },
       {
+        "disabled": true,
+        "comment": "There currently is no following functionality",
         "question": "Why can’t I see any “follower counts”?",
         "answer": "We choose not to display follower counts as part of our approach to maintaining a substantive and constructive digital forum. We feel that showing the amount of followers a user has tends to incentivize performative behavior instead of sincerity."
       },


### PR DESCRIPTION
# Summary
#1324 

- Added a field in the faqContent.json file to disable a single FAQ and then check in the FaqCard.tsx file if the disabled field is there or not.
- Also added a comment under the disabled FAQ explaining why it's disabled.

# Checklist

- [ ] On the frontend, I've made my strings translate-able.
- [ ] If I've added shared components, I've added a storybook story.
- [ ] I've made pages responsive and look good on mobile.

# Screenshots

![image](https://github.com/codeforboston/maple/assets/55262612/3c7401f8-1ab6-47e9-9ac8-a2e248455d82)


# Known issues

- Not a known issue, but slightly unsure if this would be better than just removing the single FAQ entirely and adding it back on later, just in case we forget putting it back in.

# Steps to test/reproduce

1. Go to dropdown menu
2. Click on About and then FAQ
