### PR TITLE
bill search sort_by next hearing date shows only bills with upcoming hearings

### DIFF
--- a/components/search/SortBy.tsx
+++ b/components/search/SortBy.tsx
@@ -1,33 +1,11 @@
-import { useSortBy } from "@alexjball/react-instantsearch-hooks-web"
+import {
+  useSortBy,
+  useConfigure,
+  UseConfigureProps
+} from "@alexjball/react-instantsearch-hooks-web"
 import { SortByItem } from "instantsearch.js/es/connectors/sort-by/connectSortBy"
 import Select from "react-select"
 import styled from "styled-components"
-
-const items: SortByItem[] = [
-  /**
-   * uncomment the commented sections below once Prod is pointing at the correct data
-   */
-
-  {
-    label: "Sort by Most Recent Testimony",
-    value: "bills/sort/latestTestimonyAt:desc"
-  },
-  {
-    label: "Sort by Relevance",
-    value: "bills/sort/_text_match:desc,testimonyCount:desc"
-  },
-  { label: "Sort by Testimony Count", value: "bills/sort/testimonyCount:desc" },
-  {
-    label: "Sort by Cosponsor Count",
-    value: "bills/sort/cosponsorCount:desc"
-  },
-  {
-    label: "Sort by Next Hearing Date",
-    value: "bills/sort/nextHearingAt:desc"
-  }
-]
-
-export const initialSortByValue = items[0].value
 
 const StyledSelect = styled(Select)`
   .s__control {
@@ -62,9 +40,14 @@ const StyledSelect = styled(Select)`
   }
 `
 
-export const SortBy = ({ items }: { items: SortByItem[] }) => {
+export type SortByWithConfigurationItem = SortByItem & {
+  configure?: UseConfigureProps
+}
+
+export const SortBy = ({ items }: { items: SortByWithConfigurationItem[] }) => {
   const sortBy = useSortBy({ items }),
     selected = items.find(i => i.value === sortBy.currentRefinement)!
+  useConfigure(selected.configure ?? {})
   return (
     <StyledSelect
       classNamePrefix="s"

--- a/components/search/bills/useBillSort.tsx
+++ b/components/search/bills/useBillSort.tsx
@@ -1,0 +1,42 @@
+import { useMemo, useRef } from "react"
+import { SortByWithConfigurationItem } from "../SortBy"
+
+export const useBillSort = () => {
+  const now = useRef(new Date().getTime())
+
+  // refer to
+  // https://github.com/typesense/typesense-instantsearch-adapter#with-react-instantsearch
+  const items: SortByWithConfigurationItem[] = useMemo(
+    () => [
+      {
+        label: "Sort by Most Recent Testimony",
+        value: "bills/sort/latestTestimonyAt:desc"
+      },
+      {
+        label: "Sort by Relevance",
+        value: "bills/sort/_text_match:desc,testimonyCount:desc"
+      },
+      {
+        label: "Sort by Testimony Count",
+        value: "bills/sort/testimonyCount:desc"
+      },
+      {
+        label: "Sort by Cosponsor Count",
+        value: "bills/sort/cosponsorCount:asc"
+      },
+      {
+        label: "Sort by Next Hearing Date",
+        value: "bills/sort/nextHearingAt:asc",
+        configure: {
+          numericRefinements: {
+            nextHearingAt: {
+              ">=": [now.current]
+            } as any
+          }
+        }
+      }
+    ],
+    []
+  )
+  return items
+}


### PR DESCRIPTION

# Summary
resolves #1301 

adds configuration ability to sortby dropdown
creates hook (useBillSort) to create sort items
adds configuration block to sort items to filter null and past values from nextHearingAt

