### PR TITLE
Private User Fix

### DIFF
--- a/components/TestimonyCard/Author.tsx
+++ b/components/TestimonyCard/Author.tsx
@@ -8,19 +8,18 @@ const StyledName = styled(Internal)`
 `
 
 export const Author = ({ uid, name }: { uid: string; name: string }) => {
+  // Check if profile is public, or user is owner of testimony
   const profile = usePublicProfile(uid)
-
-  const authorName = profile.loading ? "" : profile.result?.fullName
   const linkToProfile = !!profile.result
   return (
     <div>
-      {linkToProfile ? (
-        <h6>
-          <StyledName href={`/profile?id=${uid}`}>{authorName}</StyledName>
-        </h6>
-      ) : (
-        <h6>{authorName || name}</h6>
-      )}
+      <h6>
+        {linkToProfile ?
+          <StyledName href={`/profile?id=${uid}`}>{name}</StyledName>
+          :
+          name
+        }
+      </h6>
     </div>
   )
 }

--- a/components/TestimonyCard/UserInfoHeader.tsx
+++ b/components/TestimonyCard/UserInfoHeader.tsx
@@ -30,7 +30,7 @@ export const UserInfoHeader = ({
         />
       </Col>
       <Col>
-        <Author uid={testimony.authorUid} name={testimony.authorDisplayName} />
+        <Author uid={testimony.authorUid} name={testimony.fullName} />
 
         <Row className="justify-content-between mb-1">
           <Col className={styles.publishdate} xs="auto">

--- a/components/db/profile/profile.ts
+++ b/components/db/profile/profile.ts
@@ -13,6 +13,7 @@ import { firestore, storage } from "../../firebase"
 import { useProfileState } from "./redux"
 import { Profile, ProfileMember, SocialLinks, ContactInfo } from "./types"
 import { cleanSocialLinks, cleanOrgURL } from "./urlCleanup"
+import { updateUserDisplayNameTestimonies } from "../testimony/updateUserTestimonies"
 
 export type ProfileHook = ReturnType<typeof useProfile>
 
@@ -88,8 +89,19 @@ export function useProfile() {
         }
       },
       updateIsPublic: async (isPublic: boolean) => {
-        if (uid) {
+        if (uid && isPublic !== profile?.public) {
           dispatch({ updatingIsPublic: true })
+          // Update the displayName for user's testimonies
+          if (profile) {
+            await updateUserDisplayNameTestimonies(
+              uid,
+              isPublic
+                ? profile.fullName
+                  ? profile.fullName
+                  : "Anonymous"
+                : "<private user>"
+            )
+          }
           await updateIsPublic(uid, isPublic)
           dispatch({ updatingIsPublic: false })
         }
@@ -116,8 +128,13 @@ export function useProfile() {
         }
       },
       updateFullName: async (fullName: string) => {
-        if (uid) {
+        if (uid && fullName !== profile?.fullName) {
           dispatch({ updatingFullName: true })
+          // Update the displayName for user's testimonies
+          await updateUserDisplayNameTestimonies(
+            uid,
+            profile?.public ? fullName : "<private user>"
+          )
           await updateFullName(uid, fullName)
           dispatch({ updatingFullName: false })
         }

--- a/components/db/profile/profile.ts
+++ b/components/db/profile/profile.ts
@@ -95,11 +95,8 @@ export function useProfile() {
           if (profile) {
             await updateUserDisplayNameTestimonies(
               uid,
-              isPublic
-                ? profile.fullName
-                  ? profile.fullName
-                  : "Anonymous"
-                : "<private user>"
+              isPublic ? profile.fullName ?? "Anonymous" : "<private user>",
+              profile.fullName ?? "Anonymous"
             )
           }
           await updateIsPublic(uid, isPublic)
@@ -133,7 +130,8 @@ export function useProfile() {
           // Update the displayName for user's testimonies
           await updateUserDisplayNameTestimonies(
             uid,
-            profile?.public ? fullName : "<private user>"
+            profile?.public ? fullName : "<private user>",
+            fullName
           )
           await updateFullName(uid, fullName)
           dispatch({ updatingFullName: false })

--- a/components/db/testimony/types.ts
+++ b/components/db/testimony/types.ts
@@ -49,7 +49,8 @@ export const Testimony = BaseTestimony.extend({
   senatorId: Optional(String),
   senatorDistrict: Optional(String),
   representativeDistrict: Optional(String),
-  draftAttachmentId: Maybe(String)
+  draftAttachmentId: Maybe(String),
+  fullName: String
 })
 
 export type WorkingDraft = Partial<DraftTestimony>

--- a/components/db/testimony/updateUserTestimonies.ts
+++ b/components/db/testimony/updateUserTestimonies.ts
@@ -29,10 +29,7 @@ export const updateUserDisplayNameTestimonies = async (
 export const getAllTestimony = async (uid: string) => {
   // Get all the published testimony under user
   const pTestimony = getDocs(
-    query(
-      collectionGroup(firestore, "publishedTestimony"),
-      where("authorUid", "==", uid)
-    )
+    collection(firestore, `users/${uid}/publishedTestimony`)
   )
   // Get all the draft testimony under user
   const dTestimony = getDocs(

--- a/components/db/testimony/updateUserTestimonies.ts
+++ b/components/db/testimony/updateUserTestimonies.ts
@@ -1,0 +1,51 @@
+import {
+  collection,
+  collectionGroup,
+  getDocs,
+  query,
+  updateDoc,
+  where,
+  writeBatch
+} from "firebase/firestore"
+import { firestore } from "../../firebase"
+
+// Updates the displayName for all testimonies under specified user
+export const updateUserDisplayNameTestimonies = async (
+  uid: string,
+  displayName: string
+) => {
+  const batch = writeBatch(firestore)
+  return getAllTestimony(uid).then(({ publishedTestimony, draftTestimony }) => {
+    publishedTestimony.forEach(doc =>
+      batch.update(doc.ref, { authorDisplayName: displayName })
+    )
+    draftTestimony.forEach(doc =>
+      batch.update(doc.ref, { authorDisplayName: displayName })
+    )
+    batch.commit().then(result => result)
+  })
+}
+
+export const getAllTestimony = async (uid: string) => {
+  // Get all the published testimony under user
+  const pTestimony = getDocs(
+    query(
+      collectionGroup(firestore, "publishedTestimony"),
+      where("authorUid", "==", uid)
+    )
+  )
+  // Get all the draft testimony under user
+  const dTestimony = getDocs(
+    collection(firestore, `users/${uid}/draftTestimony`)
+  )
+
+  const [publishedTestimony, draftTestimony] = await Promise.all([
+    pTestimony,
+    dTestimony
+  ])
+
+  return {
+    publishedTestimony: publishedTestimony,
+    draftTestimony: draftTestimony
+  }
+}

--- a/components/db/testimony/updateUserTestimonies.ts
+++ b/components/db/testimony/updateUserTestimonies.ts
@@ -12,15 +12,22 @@ import { firestore } from "../../firebase"
 // Updates the displayName for all testimonies under specified user
 export const updateUserDisplayNameTestimonies = async (
   uid: string,
-  displayName: string
+  displayName: string,
+  fullName: string
 ) => {
   const batch = writeBatch(firestore)
   return getAllTestimony(uid).then(({ publishedTestimony, draftTestimony }) => {
     publishedTestimony.forEach(doc =>
-      batch.update(doc.ref, { authorDisplayName: displayName })
+      batch.update(doc.ref, {
+        authorDisplayName: displayName,
+        fullName: fullName
+      })
     )
     draftTestimony.forEach(doc =>
-      batch.update(doc.ref, { authorDisplayName: displayName })
+      batch.update(doc.ref, {
+        authorDisplayName: displayName,
+        fullName: fullName
+      })
     )
     batch.commit().then(result => result)
   })

--- a/components/db/testimony/useEditTestimony.test.ts
+++ b/components/db/testimony/useEditTestimony.test.ts
@@ -44,6 +44,7 @@ beforeEach(() => {
     billTitle: "fake bill",
     billId,
     content: draft.content,
+    fullName: "Anonymous",
     court: court,
     position: draft.position,
     version: 1

--- a/components/moderation/setUp/MockRecords.tsx
+++ b/components/moderation/setUp/MockRecords.tsx
@@ -43,7 +43,8 @@ export const createMockTestimony = (
     billId: billId ?? "H1002",
     court: 192,
     position: "oppose",
-    content: loremIpsum({ count: 5, units: "words" })
+    content: loremIpsum({ count: 5, units: "words" }),
+    fullName: "Anonymous"
   }
   return testimony
 }

--- a/components/testimony/TestimonyDetailPage/testimonyDetailSlice.ts
+++ b/components/testimony/TestimonyDetailPage/testimonyDetailSlice.ts
@@ -69,7 +69,7 @@ const selectTestimonyDetails = createAppSelector(({ testimonyDetail }) => {
   return {
     revisions,
     revision,
-    authorTitle: author?.fullName ?? revision.authorDisplayName,
+    authorTitle: testimony.fullName ?? "Anonymous",
     authorLink: author && `/profile?id=${author.uid}`,
     isEdited: revision.version > 1,
     bill,

--- a/functions/src/auth/createFakeTestimony.ts
+++ b/functions/src/auth/createFakeTestimony.ts
@@ -41,6 +41,7 @@ export const createFakeTestimony = functions.https.onCall(
       publishedAt: Timestamp.now(),
       court: 192,
       position: "oppose",
+      fullName: fullName,
       content: fullName + " " + fullName + " " + fullName + " " + fullName
     }
 

--- a/functions/src/testimony/publishTestimony.ts
+++ b/functions/src/testimony/publishTestimony.ts
@@ -90,7 +90,8 @@ class PublishTestimonyTransaction {
       position: this.draft.position,
       ...publishInfo,
       attachmentId: this.attachments.id,
-      draftAttachmentId: this.attachments.draftId
+      draftAttachmentId: this.attachments.draftId,
+      fullName: this.profile?.fullName ?? "Anonymous"
     }
     if (this.profile?.representative?.id) {
       newPublication.representativeId = this.profile.representative.id

--- a/functions/src/testimony/publishTestimony.ts
+++ b/functions/src/testimony/publishTestimony.ts
@@ -270,7 +270,12 @@ class PublishTestimonyTransaction {
     }
   }
 
-  private getDisplayName() {
-    return this.profile?.fullName ?? "Anonymous"
+  private getDisplayName(): string {
+    // Check if user has profile and then if they're private
+    if (this.profile) {
+      return this.profile.public ? this.profile.fullName : "<private user>"
+    } else {
+      return "Anonymous"
+    }
   }
 }

--- a/functions/src/testimony/types.ts
+++ b/functions/src/testimony/types.ts
@@ -40,7 +40,8 @@ export const Testimony = withDefaults(
     senatorId: Optional(RtString),
     senatorDistrict: Optional(RtString),
     representativeDistrict: Optional(RtString),
-    draftAttachmentId: Maybe(RtString)
+    draftAttachmentId: Maybe(RtString),
+    fullName: RtString
   }),
   {
     authorRole: "user",

--- a/scripts/firebase-admin/updateDisplayNames.ts
+++ b/scripts/firebase-admin/updateDisplayNames.ts
@@ -1,0 +1,52 @@
+import { Script } from "./types"
+
+export const script: Script = async ({ db }) => {
+  const writer = db.bulkWriter()
+  const users = await db
+    .collection("profiles")
+    .where("role", "in", ["user", "admin"])
+    .get()
+  console.log(`updating ${users.size} documents`)
+  for (const user of users.docs) {
+    try {
+      const data = user.data()
+      console.log(data)
+      const pTestimonies = db
+        .collection(`users/${user.id}/publishedTestimony`)
+        .get()
+        .then(result => result.docs)
+
+      const dTestimonies = db
+        .collection(`users/${user.id}/publishedTestimony`)
+        .get()
+        .then(result => result.docs)
+
+      const [publishedTestimony, draftTestimony] = await Promise.all([
+        pTestimonies,
+        dTestimonies
+      ])
+
+      const fullName = data.fullName ?? "Anonymous"
+      const displayName = data.public ? fullName : "<private user>"
+
+      for (const doc of publishedTestimony) {
+        writer.update(doc.ref, {
+          authorDisplayName: displayName,
+          fullName: fullName
+        })
+      }
+      for (const doc of draftTestimony) {
+        writer.update(doc.ref, {
+          authorDisplayName: displayName,
+          fullName: fullName
+        })
+      }
+    } catch (error) {
+      // Log the error and continue with the next user
+      console.error(`Error updating email for user ${user.data().id}: `, error)
+    }
+  }
+
+  await writer.close()
+  console.log(`updated ${users.size} documents`)
+}


### PR DESCRIPTION
# Summary

#1278 
- Whenever a user posts testimony, it will check if the user is private or public and will set the display name of the testimony based on that.
- Also whenever a user changes their private status or full name, it will update the display name for all the testimonies under their account, matching the private status.
- On Browse Testimony, the `<private user>` should be one of the names under the filter.

# Checklist

- [ ] On the frontend, I've made my strings translate-able.
- [ ] If I've added shared components, I've added a storybook story.
- [ ] I've made pages responsive and look good on mobile.

# Screenshots


# Known issues

- We would either need to create a script that will update all the display names for each testimony to match the user's privacy status, or we would need to ask user's to unprivate then private their account to have the changes take effect.
- Maybe create tests to ensure that the functions are working properly?

# Steps to test/reproduce

This requires running the whole application since there are some changes to the back-end

1. Either submit a testimony when your profile is private and then check on the browse testimony to see if the display name is `<private user>`
2. Or for already submitted testimonies, change your profile privacy status and then check for each testimony to see if the display name matches your status.
