### PR TITLE
Pending Upgrade Message banner

### DIFF
--- a/components/EditProfilePage/EditProfilePage.tsx
+++ b/components/EditProfilePage/EditProfilePage.tsx
@@ -22,6 +22,7 @@ import {
 } from "./StyledEditProfileComponents"
 import { TestimoniesTab } from "./TestimoniesTab"
 import { Banner } from "components/shared/StyledSharedComponents"
+import { PendingUpgradeBanner } from "components/PendingUpgradeBanner"
 
 export function EditProfile() {
   const { user } = useAuth()
@@ -117,7 +118,7 @@ export function EditProfileForm({
 
   return (
     <>
-      {isPendingUpgrade && <Banner>{t("content.reqPending")}</Banner>}
+      {isPendingUpgrade && <PendingUpgradeBanner />}
 
       <Container>
         <Header>

--- a/components/EditProfilePage/EditProfilePage.tsx
+++ b/components/EditProfilePage/EditProfilePage.tsx
@@ -79,7 +79,7 @@ export function EditProfileForm({
   const isOrg =
     profile.role === "organization" || profile.role === "pendingUpgrade"
 
-  const isPendingUpgrade = profile.role === "pendingUpgrade"
+  const isPendingUpgrade = useAuth().claims?.role === "pendingUpgrade"
 
   const { t } = useTranslation("editProfile")
 

--- a/components/PendingUpgradeBanner.tsx
+++ b/components/PendingUpgradeBanner.tsx
@@ -1,0 +1,9 @@
+import { MessageBanner } from "./shared/MessageBanner"
+
+export const PendingUpgradeBanner = () => (
+  <MessageBanner
+    icon={"/Clock.svg"}
+    heading={"Organization Request In Progress"}
+    content="Your request to be upgraded to an organization is currently in progress. You will be notified by email when your request has been reviewed."
+  />
+)

--- a/components/PendingUpgradeBanner.tsx
+++ b/components/PendingUpgradeBanner.tsx
@@ -1,9 +1,13 @@
 import { MessageBanner } from "./shared/MessageBanner"
+import { useTranslation } from "next-i18next"
 
-export const PendingUpgradeBanner = () => (
-  <MessageBanner
-    icon={"/Clock.svg"}
-    heading={"Organization Request In Progress"}
-    content="Your request to be upgraded to an organization is currently in progress. You will be notified by email when your request has been reviewed."
-  />
-)
+export const PendingUpgradeBanner = () => {
+  const { t } = useTranslation("common")
+  return (
+    <MessageBanner
+      icon={"/Clock.svg"}
+      heading={t("pending_upgrade_warning.header")}
+      content={t("pending_upgrade_warning.content")}
+    />
+  )
+}

--- a/components/ProfilePage/ProfilePage.tsx
+++ b/components/ProfilePage/ProfilePage.tsx
@@ -18,14 +18,14 @@ export function ProfilePage(profileprops: {
   id: string
   verifyisorg?: boolean
 }) {
-  const { user } = useAuth()
+  const { user, claims } = useAuth()
   const { result: profile, loading } = usePublicProfile(
     profileprops.id,
     profileprops.verifyisorg
   )
   const isMobile = useMediaQuery("(max-width: 768px)")
   const isUser = user?.uid === profileprops.id
-  const isPendingUpgrade = profile?.role === "pendingUpgrade"
+  const isPendingUpgrade = claims?.role === "pendingUpgrade"
   const isOrg: boolean =
     profile?.role === "organization" ||
     profile?.role === "pendingUpgrade" ||

--- a/components/ProfilePage/ProfilePage.tsx
+++ b/components/ProfilePage/ProfilePage.tsx
@@ -1,19 +1,18 @@
+import { PendingUpgradeBanner } from "components/PendingUpgradeBanner"
 import { useTranslation } from "next-i18next"
-import { useState, useEffect } from "react"
+import ErrorPage from "next/error"
+import { useEffect, useState } from "react"
 import { useMediaQuery } from "usehooks-ts"
+import ViewTestimony from "../TestimonyCard/ViewTestimony"
 import { useAuth } from "../auth"
 import { Col, Row, Spinner } from "../bootstrap"
 import { usePublicProfile, usePublishedTestimonyListing } from "../db"
 import { Banner } from "../shared/StyledSharedComponents"
-import ViewTestimony from "../TestimonyCard/ViewTestimony"
 import { ProfileAboutSection } from "./ProfileAboutSection"
+import { ProfileHeader } from "./ProfileHeader"
 import { ProfileLegislators } from "./ProfileLegislators"
 import { StyledContainer } from "./StyledProfileComponents"
-import { ProfileHeader } from "./ProfileHeader"
 import { VerifyAccountSection } from "./VerifyAccountSection"
-import ErrorPage from "next/error"
-import { isPending } from "@reduxjs/toolkit"
-import { PendingUpgradeBanner } from "components/PendingUpgradeBanner"
 
 export function ProfilePage(profileprops: {
   id: string
@@ -53,12 +52,6 @@ export function ProfilePage(profileprops: {
   useEffect(() => {
     onProfilePublicityChanged(profile?.public)
   }, [profile?.public])
-
-  const bannerContent = isProfilePublic ? (
-    <Banner> {t("content.publicProfile")} </Banner>
-  ) : (
-    <Banner> {t("content.privateProfile")} </Banner>
-  )
 
   return (
     <>

--- a/components/ProfilePage/ProfilePage.tsx
+++ b/components/ProfilePage/ProfilePage.tsx
@@ -12,6 +12,8 @@ import { StyledContainer } from "./StyledProfileComponents"
 import { ProfileHeader } from "./ProfileHeader"
 import { VerifyAccountSection } from "./VerifyAccountSection"
 import ErrorPage from "next/error"
+import { isPending } from "@reduxjs/toolkit"
+import { PendingUpgradeBanner } from "components/PendingUpgradeBanner"
 
 export function ProfilePage(profileprops: {
   id: string
@@ -24,6 +26,7 @@ export function ProfilePage(profileprops: {
   )
   const isMobile = useMediaQuery("(max-width: 768px)")
   const isUser = user?.uid === profileprops.id
+  const isPendingUpgrade = profile?.role === "pendingUpgrade"
   const isOrg: boolean =
     profile?.role === "organization" ||
     profile?.role === "pendingUpgrade" ||
@@ -67,8 +70,21 @@ export function ProfilePage(profileprops: {
         <>
           {profile ? (
             <>
-              {isUser && <Banner> {t("content.viewingProfile")} </Banner>}
-              {isUser && bannerContent}
+              {isUser ? (
+                isPendingUpgrade ? (
+                  <PendingUpgradeBanner />
+                ) : (
+                  <>
+                    <Banner> {t("content.viewingProfile")} </Banner>
+                    <Banner>
+                      {isProfilePublic
+                        ? t("content.publicProfile")
+                        : t("content.privateProfile")}
+                    </Banner>
+                  </>
+                )
+              ) : null}
+
               <StyledContainer>
                 <ProfileHeader
                   isMobile={isMobile}

--- a/components/bill/BillDetails.tsx
+++ b/components/bill/BillDetails.tsx
@@ -28,6 +28,7 @@ import { BillProps } from "./types"
 import { useTranslation } from "next-i18next"
 import { isCurrentCourt } from "functions/src/shared"
 import { FollowBillButton } from "components/shared/FollowButton"
+import { PendingUpgradeBanner } from "components/PendingUpgradeBanner"
 
 const StyledContainer = styled(Container)`
   font-family: "Nunito";
@@ -42,13 +43,18 @@ const StyledImage = styled(Image)`
 
 export const BillDetails = ({ bill }: BillProps) => {
   const { t } = useTranslation("common")
+
+  const isPendingUpgrade = useAuth().claims?.role === "pendingUpgrade"
+
   return (
     <>
+      {isPendingUpgrade && <PendingUpgradeBanner />}
       {!isCurrentCourt(bill.court) && (
         <Banner>
           this bill is from session {bill.court} - not the current session
         </Banner>
       )}
+
       <StyledContainer className="mt-3 mb-3">
         <Row>
           <Col>

--- a/components/publish/hooks/usePanelStatus.ts
+++ b/components/publish/hooks/usePanelStatus.ts
@@ -11,17 +11,21 @@ export type PanelStatus =
   | "createInProgress"
   | "published"
   | "editInProgress"
+  | "pendingUpgrade"
 
 /** What to display on the testimony panel on the bill detail page */
 export const usePanelStatus = (): PanelStatus => {
   const { draft, publication, sync } = usePublishState()
-  const { authenticated, user } = useAuth()
+  const { authenticated, user, claims } = useAuth()
   const loading = sync !== "synced"
+  const isPendingUpgrade = claims?.role === "pendingUpgrade"
 
   if (!authenticated) {
     return "signedOut"
   } else if (loading) {
     return "loading"
+  } else if (isPendingUpgrade) {
+    return "pendingUpgrade"
   } else if (!user?.emailVerified) {
     return "unverified"
   } else if (!draft && !publication) {

--- a/components/publish/panel/TestimonyFormPanel.tsx
+++ b/components/publish/panel/TestimonyFormPanel.tsx
@@ -6,6 +6,7 @@ import { resolveBill, usePanelStatus } from "../hooks"
 import {
   CompleteTestimony,
   CreateTestimony,
+  PendingUpgrade,
   SignedOut,
   UnverifiedEmail
 } from "./ctas"
@@ -46,6 +47,8 @@ const Panel = () => {
       return isMobile ? <></> : <CreateTestimony />
     case "createInProgress":
       return isMobile ? <></> : <CompleteTestimony />
+    case "pendingUpgrade":
+      return <PendingUpgrade />
     default:
       return <YourTestimony />
   }

--- a/components/publish/panel/ctas.tsx
+++ b/components/publish/panel/ctas.tsx
@@ -91,3 +91,16 @@ export const UnverifiedEmail = () => {
     />
   )
 }
+
+export const PendingUpgrade = () => {
+  return (
+    <Cta
+      title="Pending Upgrade"
+      cta={
+        <Button variant="primary" disabled>
+          Your Organization Registration is Pending
+        </Button>
+      }
+    />
+  )
+}

--- a/components/shared/MessageBanner.tsx
+++ b/components/shared/MessageBanner.tsx
@@ -5,7 +5,7 @@ import styled from "styled-components"
 import { Banner } from "./StyledSharedComponents"
 
 export type Props = {
-  children?: ReactNode
+children?: ReactNode
   className?: string
   heading?: string | ReactNode
   content?: string | ReactNode
@@ -32,7 +32,7 @@ const MessageBannerContent = styled("div")`
 export function MessageBanner(props: Props) {
   const { icon, heading, content, ...rest } = props
   return (
-    <Banner {...rest} className="align-items-center py-4 px-5">
+    <Banner {...rest} className="align-items-center py-4 px-3 m-0">
       <Col xs={"auto"} className="flex mh-50 p-2">
         {icon && <Image style={{ height: "2.8rem" }} src={icon} alt="" />}
       </Col>

--- a/components/shared/MessageBanner.tsx
+++ b/components/shared/MessageBanner.tsx
@@ -1,0 +1,45 @@
+import { Col, Image } from "components/bootstrap"
+import { ReactNode } from "react"
+import { RowProps } from "react-bootstrap"
+import styled from "styled-components"
+import { Banner } from "./StyledSharedComponents"
+
+export type Props = {
+  children?: ReactNode
+  className?: string
+  heading?: string | ReactNode
+  content?: string | ReactNode
+  icon?: string
+}
+
+const MessageBannerHeading = styled("div")`
+  text-align: left;
+  font-size: 1.5625rem;
+  font-style: normal;
+  font-weight: 600;
+  line-height: 2rem;
+  margin-bottom: 0.015rem;
+`
+const MessageBannerContent = styled("div")`
+  text-align: left;
+  font-size: 1rem;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 1.5rem;
+  letter-spacing: 0.015rem;
+`
+
+export function MessageBanner(props: Props) {
+  const { icon, heading, content, ...rest } = props
+  return (
+    <Banner {...rest} className="align-items-center py-4 px-5">
+      <Col xs={"auto"} className="flex mh-50 p-2">
+        {icon && <Image style={{ height: "2.8rem" }} src={icon} alt="" />}
+      </Col>
+      <Col>
+        <MessageBannerHeading>{heading}</MessageBannerHeading>
+        <MessageBannerContent>{content}</MessageBannerContent>
+      </Col>
+    </Banner>
+  )
+}

--- a/components/shared/MessageBanner.tsx
+++ b/components/shared/MessageBanner.tsx
@@ -5,7 +5,7 @@ import styled from "styled-components"
 import { Banner } from "./StyledSharedComponents"
 
 export type Props = {
-children?: ReactNode
+  children?: ReactNode
   className?: string
   heading?: string | ReactNode
   content?: string | ReactNode

--- a/components/shared/StyledSharedComponents.tsx
+++ b/components/shared/StyledSharedComponents.tsx
@@ -1,7 +1,10 @@
 import styled from "styled-components"
-import { Container, Image, Col, Row } from "../bootstrap"
+import { Row } from "../bootstrap"
 
-export const Banner = styled(Row)`
+export const Banner = styled(Row).attrs(props => ({
+  className: props.className,
+  children: props.children
+}))`
   font-family: Nunito;
   font-size: 25px;
   text-align: center;

--- a/public/Clock.svg
+++ b/public/Clock.svg
@@ -1,0 +1,18 @@
+<svg width="82" height="82" viewBox="0 0 82 82" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="41" cy="41" r="39.5" fill="none" stroke="white" stroke-width="3"/>
+<line x1="40" y1="10" x2="40" y2="5" stroke="#white" stroke-width="2" stroke-linecap="round"/>
+<line x1="40" y1="78" x2="40" y2="73" stroke="white" stroke-width="2" stroke-linecap="round"/>
+<line x1="5" y1="40" x2="9" y2="40" stroke="white" stroke-width="2" stroke-linecap="round"/>
+<line x1="72" y1="40" x2="77" y2="40" stroke="white" stroke-width="2" stroke-linecap="round"/>
+<line x1="68.1228" y1="25.5625" x2="72.2825" y2="22.9632" stroke="white" stroke-width="2" stroke-linecap="round"/>
+<line x1="9.33961" y1="58.248" x2="13.4993" y2="55.6488" stroke="white" stroke-width="2" stroke-linecap="round"/>
+<line x1="21.5592" y1="9.8713" x2="24.7121" y2="13.6287" stroke="white" stroke-width="2" stroke-linecap="round"/>
+<line x1="58.7506" y1="66.6408" x2="61.9035" y2="70.3983" stroke="white" stroke-width="2" stroke-linecap="round"/>
+<line x1="19.9471" y1="70.2699" x2="23.0999" y2="66.5125" stroke="white" stroke-width="2" stroke-linecap="round"/>
+<line x1="57.2185" y1="13.5003" x2="60.3714" y2="9.74292" stroke="white" stroke-width="2" stroke-linecap="round"/>
+<line x1="68.7979" y1="55.5461" x2="72.9575" y2="58.1454" stroke="white" stroke-width="2" stroke-linecap="round"/>
+<line x1="9.44633" y1="22.8606" x2="13.606" y2="25.4598" stroke="white" stroke-width="2" stroke-linecap="round"/>
+<line x1="40" y1="40" x2="40" y2="23" stroke="white" stroke-width="2" stroke-linecap="round"/>
+<line x1="40.9752" y1="41.4104" x2="55.1749" y2="58.3329" stroke="white" stroke-width="2" stroke-linecap="round"/>
+<circle cx="40" cy="41" r="2" fill="white" stroke="white" stroke-width="2"/>
+</svg>

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -5,5 +5,8 @@
   "short_description": "MAPLE makes it easy for anyone to view and submit testimony to the Massachusetts Legislature about the bills that will shape our future.",
   "browse_bills": "browse bills",
   "logInSignUp": "Log in / Sign up",
-  "back_to_bills": "back to list of bills"
-}
+  "back_to_bills": "back to list of bills",
+  "pending_upgrade_warning": {
+    "header": "Organization Request In Progress",
+    "content": "Your request to be upgraded to an organization is currently in progress. You will be notified by email when your request has been reviewed."
+  }}

--- a/stories/components/page/Banner.stories.tsx
+++ b/stories/components/page/Banner.stories.tsx
@@ -1,0 +1,26 @@
+import { ComponentStory } from "@storybook/react"
+import { MessageBanner } from "components/shared/MessageBanner"
+import { createMeta } from "stories/utils"
+
+export default createMeta({
+  title: "Components/Page/MessageBanner",
+  figmaUrl:
+    "https://www.figma.com/file/DsC9Nzanyb5bXsQfZ3veO9/2023-Base-File?type=design&node-id=3873-31947&mode=dev",
+  component: MessageBanner
+})
+
+const Template: ComponentStory<typeof MessageBanner> = args => {
+  return <MessageBanner {...args} />
+}
+
+export const Primary = Template.bind({})
+
+Primary.args = {
+  heading: "Organization Request In Progress",
+  content:
+    "Your request to be updated to an organization is currently in progress, you will be notified my email on if your request has been approved or denied.",
+  className: "",
+  icon: "/Clock.svg"
+}
+
+Primary.storyName = "MessageBanner"


### PR DESCRIPTION
# Summary

resolves #1171 
This PR is paired with #1293, and must be merged at the same time, or before. 

Adds banner info for pending organizations that their request is pending
Adds a new call to action status and disables button for pending orgs (can't submit testimony until verified/upgraded)

# Checklist

- [x] On the frontend, I've made my strings translate-able.
- [x] If I've added shared components, I've added a storybook story.
- [x] I've made pages responsive and look good on mobile.

# Screenshots

![image](https://github.com/codeforboston/maple/assets/30247522/b0cfc8be-0337-4061-ac9c-d2548d048721)
![image](https://github.com/codeforboston/maple/assets/30247522/c8086e1f-3944-4e66-92e6-981fb926f033)

# Known issues

needs to be merged before or with the corresponding backend change #1293

# Steps to test/reproduce

1. sign up for an org profile
1. view profile, edit profile, or bill detail pages

