### PR TITLE
Add a CODEOWNERS file for PR merges

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @sashamaryl @mertbagt @nesanders @mvictor55 @timblais @alexjball


### PR DESCRIPTION
# Summary

This addes a CODEOWNERS file to the repo, which identifies users that are responsible for merging PR's. After this file is checked in, we can update the [branch protection rule](https://github.com/codeforboston/maple/settings/branch_protection_rules/27041555) to require approval from a code owner before a PR can be merged.

Note that an owner approval is often a rubber stamp, where another developer provides the actual "LGTM" code review and the owner is making sure that the change fits in with the codebase as a whole. See [this explanation](https://abseil.io/resources/swe-book/html/ch09.html#:~:text=Approval%20from%20one%20of%20the%20code%20owners) for the process within Google.

The CODEOWNERS file supports specifying owners on individual directories, so in the future we could delegate owners approval to developers on a per-feature-directory basis. 

# Checklist

- [ ] TODO: Update branch protection rule after merging this PR.
