### PR TITLE
Fix Org name not populating on Nav Bar and error when signing up org

### DIFF
--- a/components/ProfileLink/ProfileLink.tsx
+++ b/components/ProfileLink/ProfileLink.tsx
@@ -15,6 +15,7 @@ const greeting = (role: Role, fullName?: string) => {
     case "user":
     case "legislator":
     case "organization":
+    case "pendingUpgrade":
       return fullName ? `Hello, ${fullName}` : "Hello there"
     case "admin":
       return `Hello, Admin ${fullName}`

--- a/components/auth/hooks.ts
+++ b/components/auth/hooks.ts
@@ -77,8 +77,7 @@ export function useCreateUserWithEmailAndPassword(isOrg: boolean) {
             fullName,
             orgCategories: categories,
             notificationFrequency: "Monthly",
-            email: credentials.user.email,
-            public: true
+            email: credentials.user.email
           }),
           sendEmailVerification(credentials.user)
         ])


### PR DESCRIPTION
# Summary

#1372 
- The issue with signing up a new organization was that the public field was being set during sign-up, which then gets blocked by the firestore rules. 
- There also was not a case for a display name in the Nav Bar when an organization is pending verification (pendingUpgrade). So that was added.


# Checklist

- [ ] On the frontend, I've made my strings translate-able.
- [ ] If I've added shared components, I've added a storybook story.
- [ ] I've made pages responsive and look good on mobile.

# Screenshots

_Add some screenshots highlighting your changes._

# Known issues

_If you've run against limitations or caveats, include them here. Include follow-up issues as well._

# Steps to test/reproduce

_For each feature or bug fix, create a step by step list for how a reviewer can test it out. E.g.:_

1. Sign up as an organization and check to see if the nav bar has been populated with the correct name.
