### PR TITLE
Add hyperlink to users in Browse Testimony

### DIFF
--- a/components/search/testimony/TestimonyHit.tsx
+++ b/components/search/testimony/TestimonyHit.tsx
@@ -32,11 +32,12 @@ const TestimonyResult = ({ hit }: { hit: Hit<Testimony> }) => {
   const { loading, error, result: bill } = useBill(hit.court, hit.billId)
   const committee = bill?.currentCommittee
   const isOrg = hit.authorRole === "organization"
-  const writtenBy = isOrg ? (
-    <Link href={`/profile?id=${hit.authorUid}`}>{hit.authorDisplayName}</Link>
-  ) : (
-    hit.authorDisplayName
-  )
+  const writtenBy =
+    isOrg || hit.authorDisplayName !== "<private user>" ? (
+      <Link href={`/profile?id=${hit.authorUid}`}>{hit.authorDisplayName}</Link>
+    ) : (
+      hit.authorDisplayName
+    )
   return (
     <div
       style={{


### PR DESCRIPTION
# Summary

#1388 
- Added hyperlinks to users in Browse Testimony by checking if they're an organization or if their display name is not <private user> since it would be quicker to do that than to try to get the user profile and check their public status.

# Checklist

- [ ] On the frontend, I've made my strings translate-able.
- [ ] If I've added shared components, I've added a storybook story.
- [ ] I've made pages responsive and look good on mobile.

# Screenshots

![image](https://github.com/codeforboston/maple/assets/55262612/60aa39d6-1078-4cb5-9a2c-0dc41d1d8cf9)


# Known issues

_If you've run against limitations or caveats, include them here. Include follow-up issues as well._

# Steps to test/reproduce

_For each feature or bug fix, create a step by step list for how a reviewer can test it out. E.g.:_

1. Go to Browse Testimony
2. Click on the hyperlinks to see if they link correctly.
3. Switch privacy status to see if it unlinks properly.
