### PR TITLE
Add Validation for empty spaces in fullName when creating/editing profile

### DIFF
--- a/components/EditProfilePage/PersonalInfoTab.tsx
+++ b/components/EditProfilePage/PersonalInfoTab.tsx
@@ -115,6 +115,10 @@ export function PersonalInfoTab({
             <Input
               label={t(isOrg ? "forms.orgName" : "forms.fullName")}
               {...register("fullName", {
+                value: fullName?.trim(),
+                validate: value =>
+                  value.trim().length >= 2 ||
+                  t("forms.errEmptyAndMinLength").toString(),
                 required: t(
                   isOrg ? "forms.errOrgNameRequired" : "forms.errNameRequired"
                 ).toString()

--- a/components/auth/OrgSignUpModal.tsx
+++ b/components/auth/OrgSignUpModal.tsx
@@ -125,6 +125,9 @@ export default function OrgSignUpModal({
                   label={t("orgName")}
                   type="text"
                   {...register("fullName", {
+                    validate: value =>
+                      value.trim().length >= 2 ||
+                      t("errEmptyAndMinLength").toString(),
                     required: t("nameIsRequired") ?? "A full name is required."
                   })}
                   error={errors.fullName?.message}

--- a/components/auth/UserSignUpModal.tsx
+++ b/components/auth/UserSignUpModal.tsx
@@ -114,6 +114,9 @@ export default function UserSignUpModal({
                   label={t("fullName")}
                   type="text"
                   {...register("fullName", {
+                    validate: value =>
+                      value.trim().length >= 2 ||
+                      t("errEmptyAndMinLength").toString(),
                     required: t("nameIsRequired") ?? "A full name is required."
                   })}
                   error={errors.fullName?.message}

--- a/public/locales/en/auth.json
+++ b/public/locales/en/auth.json
@@ -23,6 +23,7 @@
   "orgName": "Organization Name",
   "fullName": "Full Name",
   "nameIsRequired": "A full name is required",
+  "errEmptyAndMinLength": "Should have at least two characters",
   "selectOrgCat": "Select an organization category",
   "passwordRequired": "A password is required.",
   "passwordLength": "Your password must be 8 characters or longer.",

--- a/public/locales/en/editProfile.json
+++ b/public/locales/en/editProfile.json
@@ -57,6 +57,7 @@
         "makePrivate": "Make Private",
         "errNameRequired": "Name is required",
         "errOrgNameRequired" : "Organization Name is required",
+        "errEmptyAndMinLength": "Should have at least two characters",
         "aboutYou": "Write something about yourself",
         "aboutYouTip":"What should you write?",
         "selectOrgCategory": "Select an organization cateogry",


### PR DESCRIPTION
# Summary

#1394 

- Added an extra validation for empty strings and to have at least 2 characters in the fullName field
- Also trimmed the field so that there aren't any extra surrounding whitespace in the fullName value

# Checklist

- [ ] On the frontend, I've made my strings translate-able.
- [ ] If I've added shared components, I've added a storybook story.
- [ ] I've made pages responsive and look good on mobile.

# Screenshots


https://github.com/codeforboston/maple/assets/55262612/cf128f9b-d69c-4089-bf54-560d7b9070b1

# Known issues

_If you've run against limitations or caveats, include them here. Include follow-up issues as well._

# Steps to test/reproduce

_For each feature or bug fix, create a step by step list for how a reviewer can test it out. E.g.:_

1. Go to Sign up and try creating a profile with less than 2 non-space characters and check if the error message appears.
2. After creating a profile, check in the edit profile page and do the same check in step 1.
