### PR TITLE
Use Node 16 to deploy firebase.

### DIFF
--- a/.github/workflows/deploy-backend-dev.yml
+++ b/.github/workflows/deploy-backend-dev.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Build Environment
         uses: ./.github/actions/setup-repo
       - name: Build and Deploy to Firebase
-        uses: w9jds/firebase-action@master
+        uses: w9jds/firebase-action@v12.9.0
         with:
           args: deploy --force --only firestore,functions,storage
         env:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Build Environment
         uses: ./.github/actions/setup-repo
       - name: Build and Deploy to Firebase
-        uses: w9jds/firebase-action@master
+        uses: w9jds/firebase-action@v12.9.0
         with:
           args: deploy --force --only firestore,functions,storage
         env:


### PR DESCRIPTION
# Summary
The direbase-action docker container updated to firebase tools
v13 and Node 18 2 weeks ago. Since our workflow used the `master` tag, it started
using that new version in recent runs, which fails because our firebase
functions require node 16. So we just need to use an older version of
the image from last month for deploys to work. PR #1385 updates to node
18, but this will allow us to fix the current prod deployment before
then.


