### PR TITLE
Fixed separate recipients and body format

### DIFF
--- a/components/publish/hooks/useTestimonyEmail.ts
+++ b/components/publish/hooks/useTestimonyEmail.ts
@@ -12,7 +12,7 @@ export const useTestimonyEmail = () => {
 
   const to = share.recipients
       .map(r => `${r.Name} <${r.EmailAddress}>`)
-      .join(","),
+      .join(";"),
     billId = formatBillId(bill?.id!),
     intro = `As your constituent, I am writing to let you know that I ${
       positionActions[position!]
@@ -39,12 +39,11 @@ export const useTestimonyEmail = () => {
     .filter(Boolean)
     .join("\n\n")
 
-  const plainBody = formatTestimonyPlaintext(markdownBody),
-    htmlBody = formatTestimony(markdownBody).__html
+  const htmlBody = formatTestimony(markdownBody).__html
 
   const mailToUrl = `mailto:${to}?subject=${encodeURIComponent(
     subject
-  )}&body=${encodeURIComponent(plainBody)}`
+  )}&body=${encodeURIComponent(markdownBody)}`
 
   if (profile) {
     return { ready: true, mailToUrl, body: htmlBody, to } as const

--- a/components/publish/hooks/useTestimonyEmail.ts
+++ b/components/publish/hooks/useTestimonyEmail.ts
@@ -39,11 +39,12 @@ export const useTestimonyEmail = () => {
     .filter(Boolean)
     .join("\n\n")
 
-  const htmlBody = formatTestimony(markdownBody).__html
+  const plainBody = formatTestimonyPlaintext(markdownBody),
+    htmlBody = formatTestimony(markdownBody).__html
 
   const mailToUrl = `mailto:${to}?subject=${encodeURIComponent(
     subject
-  )}&body=${encodeURIComponent(markdownBody)}`
+  )}&body=${encodeURIComponent(plainBody)}`
 
   if (profile) {
     return { ready: true, mailToUrl, body: htmlBody, to } as const

--- a/components/testimony/formatting.test.ts
+++ b/components/testimony/formatting.test.ts
@@ -1,5 +1,9 @@
 import { dump } from "js-yaml"
-import { formatTestimony, formatTestimonyDiff } from "./formatting"
+import {
+  formatTestimony,
+  formatTestimonyDiff,
+  formatTestimonyPlaintext
+} from "./formatting"
 const curr = `
 Testimony Version 2
 
@@ -39,6 +43,8 @@ describe("formatTestimony", () => {
     md: string
     html?: string
     check?: (html: string) => void
+    plainText?: string
+    checkPlain?: (plain: string) => void
   }>([
     {
       testCase: "empty",
@@ -126,6 +132,52 @@ lheading 2
       check = actual => expect(actual).toEqual(expectedHtml)
     }) => {
       const actual = formatTestimony(md).__html
+      check(actual)
+    }
+  )
+})
+
+describe("formatTestimonyPlaintext", () => {
+  test.each<{
+    testCase: string
+    md: string
+    plainText?: string
+    check?: (plainText: string) => void
+  }>([
+    {
+      testCase: "empty",
+      md: "",
+      plainText: ``
+    },
+    {
+      md: `some text
+with newlines
+
+and paragraph breaks`,
+      plainText: `some text
+with newlines
+
+and paragraph breaks`,
+      testCase: "newlines and paragraphs"
+    },
+    {
+      md: `some **text** with _styling_ and ~~formatting~~`,
+      plainText: `some text with styling and formatting`,
+      testCase: "styling"
+    },
+    {
+      md: `some text with a [link](https://example.com) and unformatted link https://google.com.`,
+      plainText: `some text with a link (https://example.com/) and unformatted link https://google.com/.`,
+      testCase: "links"
+    }
+  ])(
+    "$testCase",
+    ({
+      plainText: expectedPlain,
+      md,
+      check = actual => expect(actual).toEqual(expectedPlain)
+    }) => {
+      const actual = formatTestimonyPlaintext(md)
       check(actual)
     }
   )

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,21 @@
+const nextJest = require('next/jest')
+
+/** @type {import('jest').Config} */
+const createJestConfig = nextJest({
+    // Provide the path to your Next.js app to load next.config.js and .env files in your test environment
+    dir: './',
+})
+
+// Add any custom config to be passed to Jest
+const config = {
+    coverageProvider: 'v8',
+    testEnvironment: 'jsdom',
+    moduleNameMapper: {
+        "^components/(.*)$": "<rootDir>/components/$1"
+    }
+    // Add more setup options before each test is run
+    // setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+}
+
+// createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async
+module.exports = createJestConfig(config)

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,20 +1,20 @@
-const nextJest = require('next/jest')
+const nextJest = require("next/jest")
 
 /** @type {import('jest').Config} */
 const createJestConfig = nextJest({
-    // Provide the path to your Next.js app to load next.config.js and .env files in your test environment
-    dir: './',
+  // Provide the path to your Next.js app to load next.config.js and .env files in your test environment
+  dir: "./"
 })
 
 // Add any custom config to be passed to Jest
 const config = {
-    coverageProvider: 'v8',
-    testEnvironment: 'jsdom',
-    moduleNameMapper: {
-        "^components/(.*)$": "<rootDir>/components/$1"
-    }
-    // Add more setup options before each test is run
-    // setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  coverageProvider: "v8",
+  testEnvironment: "jsdom",
+  moduleNameMapper: {
+    "^components/(.*)$": "<rootDir>/components/$1"
+  }
+  // Add more setup options before each test is run
+  // setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
 }
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async


### PR DESCRIPTION
# Summary

#1403 
- Fixed formatting of recipients for email so that each of them is separated
- Changed the email body that is being sent in the URL, so that the body is being formatted instead of just plain text

# Checklist

- [ ] On the frontend, I've made my strings translate-able.
- [ ] If I've added shared components, I've added a storybook story.
- [ ] I've made pages responsive and look good on mobile.

# Screenshots

![image](https://github.com/codeforboston/maple/assets/55262612/66d326af-2e3b-4f9a-bbdc-c29a361040ee)

# Known issues

- This removes the use of the plain body copy of the text, which in turn, makes the formatTestimonyPlaintext method obsolete, so unsure of what to do with that method.

# Steps to test/reproduce

_For each feature or bug fix, create a step by step list for how a reviewer can test it out. E.g.:_

1. Create testimony
2. Click on Send Email to check if the body is formatted properly and the recipients are separated.
