### PR TITLE
Fix bug where draft saving hangs in testimony form

### DIFF
--- a/components/publish/WriteTestimony.tsx
+++ b/components/publish/WriteTestimony.tsx
@@ -1,21 +1,17 @@
-import clsx from "clsx"
 import { useCallback, useEffect, useState } from "react"
 import styled from "styled-components"
-import { useAuth } from "../auth"
-import { Tab, Tabs } from "../bootstrap"
 import { Attachment } from "../CommentModal/Attachment"
+import { useAuth } from "../auth"
 import { useDraftTestimonyAttachment } from "../db"
 import { Maybe } from "../db/common"
-import Input, { InputProps } from "../forms/Input"
+import { TextArea } from "../forms/Input"
 import { useAppDispatch } from "../hooks"
-import { Loading } from "../legislatorSearch"
-import { useFormRedirection, usePublishState } from "./hooks"
+import * as links from "../links"
 import * as nav from "./NavigationButtons"
-import { setAttachmentId, setContent } from "./redux"
 import { SelectRecipients } from "./SelectRecipients"
 import { StepHeader } from "./StepHeader"
-import * as links from "../links"
-import { TextArea } from "../forms/Input"
+import { useFormRedirection, usePublishState } from "./hooks"
+import { setAttachmentId, setContent } from "./redux"
 type TabKey = "text" | "import"
 type UseWriteTestimony = ReturnType<typeof useWriteTestimony>
 
@@ -54,7 +50,9 @@ export const WriteTestimony = styled(props => {
 
       <div className="mt-4">
         <TextArea
-          {...write}
+          setContent={write.setContent}
+          content={write.content}
+          error={write.error}
           label="Testimony"
           placeholder="Add your testimony here"
           help="Testimony is limited to 10,000 characters."


### PR DESCRIPTION
Closes #1401 

# Summary

There is a race condition between when async draft saving starts and when useFormSync renders, such that this effect can run again before loading becomes true.

This causes the draft saving logic to run again, but by that point the document has already been updated. This causes loadingDraft to be dispatched in useEditTestimony, but not loadDraft, because the snapshot listener only runs when the document actually changes.

The fix here is not to try to save the draft unless the form values actually change.

# Steps to test/reproduce

Go to create testimony on a bill, select an initial stance/testimony content, and then change it. currently this causes the saving draft spinner to hang. this PR fixes that
