### PR TITLE
refactor profile icons to fix styled comp error

### DIFF
--- a/components/ProfilePage/ProfileHeader.tsx
+++ b/components/ProfilePage/ProfileHeader.tsx
@@ -4,7 +4,7 @@ import {
   ProfileDisplayName,
   ProfileDisplayNameSmall
 } from "./StyledProfileComponents"
-import { StyledProfileIcon } from "./StyledUserIcons"
+import { ProfileIcon } from "./StyledUserIcons"
 
 import { flags } from "components/featureFlags"
 import { FollowOrgButton } from "components/shared/FollowButton"
@@ -51,14 +51,13 @@ export const ProfileHeader = ({
         <Header className={`gx-0 edit-profile-header`}>
           <Row xs={"auto"}>
             <Col xs={"auto"} className={"col-auto"}>
-              <StyledProfileIcon large />
+              <ProfileIcon isOrg={isOrg} large />
             </Col>
             <Col className={isOrg ? `` : `d-flex`}>
               <Stack gap={0}>
                 <ProfileDisplayName
-                  className={`overflow-hidden ${
-                    isOrg ? "" : "d-flex align-items-center"
-                  }`}
+                  className={`overflow-hidden ${isOrg ? "" : "d-flex align-items-center"
+                    }`}
                 >
                   {profile.fullName}
                 </ProfileDisplayName>
@@ -133,7 +132,7 @@ function ProfileHeaderMobile({
   return (
     <Header className={``}>
       <Col className={`d-flex align-items-center justify-content-start`}>
-        <StyledProfileIcon
+        <ProfileIcon
           profileImage={profile.profileImage}
           isOrg={isOrg}
           className={`me-2`}

--- a/components/ProfilePage/ProfileHeader.tsx
+++ b/components/ProfilePage/ProfileHeader.tsx
@@ -56,8 +56,9 @@ export const ProfileHeader = ({
             <Col className={isOrg ? `` : `d-flex`}>
               <Stack gap={0}>
                 <ProfileDisplayName
-                  className={`overflow-hidden ${isOrg ? "" : "d-flex align-items-center"
-                    }`}
+                  className={`overflow-hidden ${
+                    isOrg ? "" : "d-flex align-items-center"
+                  }`}
                 >
                   {profile.fullName}
                 </ProfileDisplayName>

--- a/components/ProfilePage/ProfileHeader.tsx
+++ b/components/ProfilePage/ProfileHeader.tsx
@@ -1,13 +1,10 @@
 import { Col, Row, Stack } from "../bootstrap"
 import {
   Header,
-  OrgIconLarge,
-  OrgIconSmall,
   ProfileDisplayName,
-  ProfileDisplayNameSmall,
-  UserIconLarge,
-  UserIconSmall
+  ProfileDisplayNameSmall
 } from "./StyledProfileComponents"
+import { StyledProfileIcon } from "./StyledUserIcons"
 
 import { flags } from "components/featureFlags"
 import { FollowOrgButton } from "components/shared/FollowButton"
@@ -38,14 +35,6 @@ export const ProfileHeader = ({
 }) => {
   const { t } = useTranslation("profile")
 
-  const orgImageSrc = profile.profileImage
-    ? profile.profileImage
-    : "/profile-org-icon.svg"
-
-  const userImageSrc = profile.profileImage
-    ? profile.profileImage
-    : "/profile-individual-icon.svg"
-
   return (
     <>
       {isMobile ? (
@@ -55,23 +44,15 @@ export const ProfileHeader = ({
           isProfilePublic={isProfilePublic}
           onProfilePublicityChanged={onProfilePublicityChanged}
           isUser={isUser}
-          orgImageSrc={orgImageSrc}
           profile={profile}
           profileId={profileId}
-          userImageSrc={userImageSrc}
         />
       ) : (
         <Header className={`gx-0 edit-profile-header`}>
           <Row xs={"auto"}>
-            {isOrg ? (
-              <Col xs={"auto"} className={"col-auto"}>
-                <OrgIconLarge alt={t("orgIcon.large")} src={orgImageSrc} />
-              </Col>
-            ) : (
-              <Col>
-                <UserIconLarge alt={t("userIcon.large")} src={userImageSrc} />
-              </Col>
-            )}
+            <Col xs={"auto"} className={"col-auto"}>
+              <StyledProfileIcon large />
+            </Col>
             <Col className={isOrg ? `` : `d-flex`}>
               <Stack gap={0}>
                 <ProfileDisplayName
@@ -134,10 +115,8 @@ function ProfileHeaderMobile({
   isProfilePublic,
   onProfilePublicityChanged,
   isUser,
-  orgImageSrc,
   profile,
   profileId,
-  userImageSrc,
   uid
 }: {
   isMobile: boolean
@@ -145,22 +124,20 @@ function ProfileHeaderMobile({
   isProfilePublic: boolean | undefined
   onProfilePublicityChanged: (isPublic: boolean) => void
   isUser: boolean
-  orgImageSrc: string
   profile: Profile
   profileId: string
-  userImageSrc: string
   uid?: string
 }) {
   const { t } = useTranslation("profile")
 
   return (
     <Header className={``}>
-      <Col className={`d-flex align-items-center`}>
-        {isOrg ? (
-          <OrgIconSmall alt={t("orgIcon.small")} src={orgImageSrc} />
-        ) : (
-          <UserIconSmall alt={t("userIcon.small")} src={userImageSrc} />
-        )}
+      <Col className={`d-flex align-items-center justify-content-start`}>
+        <StyledProfileIcon
+          profileImage={profile.profileImage}
+          isOrg={isOrg}
+          className={`me-2`}
+        />
 
         <ProfileDisplayNameSmall className={`ms-auto overflow-hidden`}>
           {profile.fullName}

--- a/components/ProfilePage/StyledProfileComponents.tsx
+++ b/components/ProfilePage/StyledProfileComponents.tsx
@@ -22,41 +22,11 @@ export const ContactInfoRow = styled(Row)`
   font-weight: 500;
 `
 
-export const UserIconLarge = ({ alt, src }: { alt: string; src: string }) => {
-  const BaseUserIconLarge = styled(Image).attrs(props => ({
-    alt: alt,
-    src: src || "/profile-individual-icon.svg",
-    className: props.className
-  }))`
-    height: 7rem;
-    border-radius: 50%;
-    background-color: var(--bs-white);
-    flex: 0;
-    margin-right: 2rem;
-  `
-
-  return <BaseUserIconLarge />
-}
-
-export const UserIconSmall = ({ alt, src }: { alt: string; src: string }) => {
-  const BaseUserIconSmall = styled(Image).attrs(props => ({
-    alt: alt,
-    src: src || "/profile-individual-icon.svg",
-    className: props.className
-  }))`
-    height: 5rem;
-    border-radius: 50%;
-    background-color: var(--bs-white);
-    flex: 0;
-    margin-right: 2rem;
-  `
-
-  return <BaseUserIconSmall />
-}
-
-export const ProfileDisplayName = styled(Col).attrs(props => ({
-  className: `${props.className}`
-}))`
+export const ProfileDisplayName = styled(Col).attrs<{ large: boolean }>(
+  props => ({
+    className: `${props.className}`
+  })
+)`
   margin: 0;
   max-height: 108px;
   font-family: Nunito;
@@ -86,38 +56,6 @@ export const ProfileDisplayNameSmall = styled(Col).attrs(props => ({
   text-align: left;
   color: #000;
 `
-
-export const OrgIconLarge = ({ alt, src }: { alt: string; src: string }) => {
-  const BaseOrgIconLarge = styled(Image).attrs(props => ({
-    alt: alt,
-    src: src || "/profile-org-icon.svg",
-    className: props.className
-  }))`
-    height: 8rem;
-    margin-right: 2rem;
-    border-radius: 50%;
-    background-color: var(--bs-white);
-    flex: 0;
-  `
-
-  return <BaseOrgIconLarge />
-}
-
-export const OrgIconSmall = ({ alt, src }: { alt: string; src: string }) => {
-  const BaseOrgIconSmall = styled(Image).attrs(props => ({
-    alt: alt,
-    src: src || "/profile-org-icon.svg",
-    className: props.className
-  }))`
-    height: 5rem;
-    margin-right: 2rem;
-    border-radius: 50%;
-    background-color: var(--bs-white);
-    flex: 0;
-  `
-
-  return <BaseOrgIconSmall />
-}
 
 export const StyledContainer = styled(Container)`
   .about-me-checkbox input {

--- a/components/ProfilePage/StyledUserIcons.tsx
+++ b/components/ProfilePage/StyledUserIcons.tsx
@@ -8,7 +8,7 @@ type ProfileIconProps = {
   large?: boolean
 }
 
-export const ProfileIcon = ({
+export const BaseProfileIcon = ({
   profileImage,
   isOrg,
   className
@@ -25,7 +25,7 @@ export const ProfileIcon = ({
   )
 }
 
-export const StyledProfileIcon = styled(ProfileIcon).attrs<{ large: boolean }>(
+export const ProfileIcon = styled(BaseProfileIcon).attrs<{ large: boolean }>(
   props => ({})
 )`
   height: ${({ large }) => (large ? "7rem" : "5rem")};

--- a/components/ProfilePage/StyledUserIcons.tsx
+++ b/components/ProfilePage/StyledUserIcons.tsx
@@ -1,0 +1,35 @@
+import { Image } from "components/bootstrap"
+import styled from "styled-components"
+
+type ProfileIconProps = {
+  profileImage?: string
+  isOrg?: boolean
+  className?: string
+  large?: boolean
+}
+
+export const ProfileIcon = ({
+  profileImage,
+  isOrg,
+  className
+}: ProfileIconProps) => {
+  const defaultIconSrc: string = "/profile-individual-icon.svg"
+  const defaultOrgIconSrc: string = "/profile-org-icon.svg"
+
+  return (
+    <Image
+      src={profileImage || (isOrg ? defaultOrgIconSrc : defaultIconSrc)}
+      className={`${className}`}
+      alt="profile icon"
+    />
+  )
+}
+
+export const StyledProfileIcon = styled(ProfileIcon).attrs<{ large: boolean }>(
+  props => ({})
+)`
+  height: ${({ large }) => (large ? "7rem" : "5rem")};
+  width: ${({ large }) => (large ? "7rem" : "5rem")};
+  border-radius: 50%;
+  background-color: var(--bs-white);
+`

--- a/stories/molecules/Icons.stories.tsx
+++ b/stories/molecules/Icons.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta } from "@storybook/react"
-import { StyledProfileIcon } from "components/ProfilePage/StyledUserIcons"
+import { ProfileIcon } from "components/ProfilePage/StyledUserIcons"
 import React from "react"
 
 const IconStories = ({
@@ -21,12 +21,12 @@ export const Primary = {
   args: {
     children: (
       <IconStories className={`d-flex flex-row gap-5`}>
-        <StyledProfileIcon large />
-        <StyledProfileIcon />
-        <StyledProfileIcon isOrg large />
-        <StyledProfileIcon isOrg />
-        <StyledProfileIcon profileImage="/codeforbostonicon.png" />
-        <StyledProfileIcon large profileImage="/codeforbostonicon.png" />
+        <ProfileIcon large />
+        <ProfileIcon />
+        <ProfileIcon isOrg large />
+        <ProfileIcon isOrg />
+        <ProfileIcon profileImage="/codeforbostonicon.png" />
+        <ProfileIcon large profileImage="/codeforbostonicon.png" />
       </IconStories>
     )
   },

--- a/stories/molecules/Icons.stories.tsx
+++ b/stories/molecules/Icons.stories.tsx
@@ -1,14 +1,15 @@
 import { Meta } from "@storybook/react"
-import {
-  OrgIconLarge,
-  OrgIconSmall,
-  UserIconLarge,
-  UserIconSmall
-} from "components/ProfilePage/StyledProfileComponents"
+import { StyledProfileIcon } from "components/ProfilePage/StyledUserIcons"
 import React from "react"
 
-const IconStories = ({ children }: { children: React.ReactNode }) => {
-  return <div>{children}</div>
+const IconStories = ({
+  children,
+  className
+}: {
+  children: React.ReactNode
+  className?: string
+}) => {
+  return <div className={className}>{children}</div>
 }
 
 const meta: Meta = {
@@ -19,12 +20,13 @@ const meta: Meta = {
 export const Primary = {
   args: {
     children: (
-      <IconStories>
-        {/* <UserIconLarge />
-    <UserIconSmall />
-    <OrgIconLarge />
-    <OrgIconSmall /> */}
-        <div>TODO</div>
+      <IconStories className={`d-flex flex-row gap-5`}>
+        <StyledProfileIcon large />
+        <StyledProfileIcon />
+        <StyledProfileIcon isOrg large />
+        <StyledProfileIcon isOrg />
+        <StyledProfileIcon profileImage="/codeforbostonicon.png" />
+        <StyledProfileIcon large profileImage="/codeforbostonicon.png" />
       </IconStories>
     )
   },


### PR DESCRIPTION
# Summary

Addresses error thrown by profile icons: styled components being defined within a rendering component. 


# Checklist

- n/a On the frontend, I've made my strings translate-able.
- [x] If I've added shared components, I've added a storybook story.
- [n/a] I've made pages responsive and look good on mobile.

# Screenshots
individual profile: 
![Screenshot 2024-01-15 131331](https://github.com/codeforboston/maple/assets/30247522/ea8e8219-ecac-4bb6-9390-e23a95f0bbfb)

org profile: 
![image](https://github.com/codeforboston/maple/assets/30247522/02f390d4-7be0-4aa6-8c2c-b6d5cca4e5be)

ind, org, provided image, large and small:
![Screenshot 2024-01-15 133711](https://github.com/codeforboston/maple/assets/30247522/cd917a93-9137-4ca5-93ff-9eaede91eb2b)

# Steps to test/reproduce


1. Go to the profile page
1. See that the profile images match the figma
1. Check the console for errors
