### PR TITLE
Fixing profile page

### DIFF
--- a/components/ProfilePage/ProfilePage.tsx
+++ b/components/ProfilePage/ProfilePage.tsx
@@ -23,7 +23,7 @@ export function ProfilePage(profileprops: {
     profileprops.id,
     profileprops.verifyisorg
   )
-  const isUser = user?.uid === profileprops.id
+  const isCurrentUser = user?.uid === profileprops.id
   const role: Role = profile?.role || "user"
   const isPendingUpgrade = claims?.role === "pendingUpgrade"
   const isOrg: boolean =
@@ -82,8 +82,8 @@ export function ProfilePage(profileprops: {
 
   return (
     <>
-      {isPendingUpgrade && <PendingUpgradeBanner />}
-      {["user", "admin"].includes(role) ? (
+      {isPendingUpgrade && isCurrentUser && <PendingUpgradeBanner />}
+      {["user", "admin"].includes(role) && isCurrentUser ? (
         <>
           <Banner>
             {" "}
@@ -98,14 +98,14 @@ export function ProfilePage(profileprops: {
       <Container>
         <ProfileHeader
           profileId={profileprops.id}
-          isUser={isUser}
+          isUser={isCurrentUser}
           isOrg={isOrg}
           isProfilePublic={isProfilePublic}
           onProfilePublicityChanged={onProfilePublicityChanged}
           profile={profile}
         />
 
-        {isUser && !user.emailVerified ? (
+        {isCurrentUser && !user.emailVerified ? (
           <Row>
             <Col>
               <VerifyAccountSection className="mb-4" user={user} />


### PR DESCRIPTION
 to only show the banners for if you are the current user, not if you are any user

# Summary

Address the issue @mvictor55 found with the dev environment.

# Checklist

- [na] On the frontend, I've made my strings translate-able.
- [na] If I've added shared components, I've added a storybook story.
- [na] I've made pages responsive and look good on mobile.

# Screenshots

_Add some screenshots highlighting your changes._

# Known issues

_If you've run against limitations or caveats, include them here. Include follow-up issues as well._

# Steps to test/reproduce

_For each feature or bug fix, create a step by step list for how a reviewer can test it out. E.g.:_

