### PR TITLE
Fix Cosponsor Bill Sort Order

### DIFF
--- a/components/search/bills/useBillSort.tsx
+++ b/components/search/bills/useBillSort.tsx
@@ -22,7 +22,7 @@ export const useBillSort = () => {
       },
       {
         label: "Sort by Cosponsor Count",
-        value: "bills/sort/cosponsorCount:asc"
+        value: "bills/sort/cosponsorCount:desc"
       },
       {
         label: "Sort by Next Hearing Date",


### PR DESCRIPTION
# Summary

The Cosponsor sort on the Bills page defaults to ascending order (so bills with no cosponsors come up first). We would rather have bills with many cosponsors show up first, so this PR just switches the default sort order to make that happen.

# Checklist

- [na] On the frontend, I've made my strings translate-able.
- [na] If I've added shared components, I've added a storybook story.
- [na] I've made pages responsive and look good on mobile.

# Screenshots

_Add some screenshots highlighting your changes._

# Known issues

_If you've run against limitations or caveats, include them here. Include follow-up issues as well._

# Steps to test/reproduce

_For each feature or bug fix, create a step by step list for how a reviewer can test it out. E.g.:_

1. Go to the bills page
2. Sort by Cosponsor
3. Ensure that the first item has many cosponsors and later items have fewer cosponsors
