### PR TITLE
Update Key Prop for Calendar Event

### DIFF
--- a/components/HearingsScheduled/HearingsScheduled.tsx
+++ b/components/HearingsScheduled/HearingsScheduled.tsx
@@ -184,7 +184,7 @@ export const HearingsScheduled = () => {
                     <Row className="gx-5 justify-content-center">
                       {thisMonthsEvents?.map(e => {
                         return (
-                          <Col xxl={6} key={e.id}>
+                          <Col xxl={6} key={`${e.id}-${e.type}`}>
                             <EventCard
                               index={e.index}
                               type={e.type}


### PR DESCRIPTION
# Summary

Just saw a duplicate key error in the `HearingsScheduled` carousel when poking around the site locally. It looks like we're just using the id of the underlying event for the key, but we have different types of events pulled from different sources that can (and in at least one case this month, did) have the same key. Adding type to the key here should guarantee the key's uniqueness going forward.

# Checklist

- [na] On the frontend, I've made my strings translate-able.
- [na] If I've added shared components, I've added a storybook story.
- [na] I've made pages responsive and look good on mobile.

# Screenshots

N/A

# Known issues

N/A

# Steps to test/reproduce

1. Go to the home page
2. Open the browser console
3. See that there are no warnings about  
