### PR TITLE
Fix links to testimony detail page and adjust scraper timeouts

### DIFF
--- a/functions/src/bills/bills.ts
+++ b/functions/src/bills/bills.ts
@@ -16,7 +16,7 @@ export const { fetchBatch: fetchBillBatch, startBatches: startBillBatches } =
     resourcesPerBatch: 50,
     startBatchSchedule: "every 3 hours",
     fetchBatchTimeout: 240,
-    startBatchTimeout: 60,
+    startBatchTimeout: 240,
     fetchResource: async (court: number, id: string, current) => {
       const content = await api.getDocument({ id, court })
       const history = await api

--- a/functions/src/members/scrapeMembers.ts
+++ b/functions/src/members/scrapeMembers.ts
@@ -3,16 +3,20 @@ import { createScraper } from "../scraper"
 
 /**
  * There are around 200 members, whom we scrape every day.
+ *
+ * The member record lists all bills they are a sponsor or cosponsor of, and
+ * each of those objects list all sponsors and cosponsors. So late in the court,
+ * the responses are **huge**.
  */
 export const {
   fetchBatch: fetchMemberBatch,
   startBatches: startMemberBatches
 } = createScraper({
   resourceName: "members",
-  batchesPerRun: 10,
-  resourcesPerBatch: 100,
-  startBatchSchedule: "every 24 hours",
-  fetchBatchTimeout: 240,
+  batchesPerRun: 20,
+  resourcesPerBatch: 5,
+  startBatchSchedule: "every 8 hours",
+  fetchBatchTimeout: 300,
   startBatchTimeout: 60,
   fetchResource: async (court: number, id: string) => ({
     content: await api.getMember({ id, court })

--- a/pages/testimony/[...testimonyDetail].tsx
+++ b/pages/testimony/[...testimonyDetail].tsx
@@ -127,10 +127,10 @@ export const getServerSideProps = wrapper.getServerSideProps(
 
     if (!docs) return notFound
     else if (!q.version) {
-      console.log("redirecting", ctx.resolvedUrl, docs.testimony.version)
+      const baseUrl = ctx.resolvedUrl.split("?")[0]
       return {
         redirect: {
-          destination: `${ctx.resolvedUrl}/${docs.testimony.version}`,
+          destination: `${baseUrl}/${docs.testimony.version}`,
           permanent: false
         }
       }

--- a/pages/testimony/[...testimonyDetail].tsx
+++ b/pages/testimony/[...testimonyDetail].tsx
@@ -6,13 +6,13 @@ import {
   TestimonyDetailPage,
   useCurrentTestimonyDetails
 } from "components/testimony/TestimonyDetailPage"
+import { first } from "lodash"
+import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 import Router from "next/router"
 import { ParsedUrlQuery } from "querystring"
 import { useEffect } from "react"
 import { z } from "zod"
 import { createPage } from "../../components/page"
-import { first } from "lodash"
-import { serverSideTranslations } from "next-i18next/serverSideTranslations"
 
 export default createPage({
   title: "Testimony",
@@ -120,21 +120,21 @@ export const getServerSideProps = wrapper.getServerSideProps(
 
     const q = parseQuery(ctx.query)
 
-    console.log("q", q)
     if (!q) return notFound
     const docs = await fetchDocs(q)
 
     console.log("docs", docs)
 
     if (!docs) return notFound
-    else if (!q.version)
+    else if (!q.version) {
+      console.log("redirecting", ctx.resolvedUrl, docs.testimony.version)
       return {
         redirect: {
           destination: `${ctx.resolvedUrl}/${docs.testimony.version}`,
           permanent: false
         }
       }
-    else if (q.version > docs.testimony.version) return notFound
+    } else if (q.version > docs.testimony.version) return notFound
 
     store.dispatch(
       pageDataLoaded({

--- a/pages/testimony/[...testimonyDetail].tsx
+++ b/pages/testimony/[...testimonyDetail].tsx
@@ -59,13 +59,19 @@ const parseQuery = (query: ParsedUrlQuery) => {
 
   switch (params.length) {
     case 1:
-      return { publishedId: params[0] }
+      return { params, publishedId: params[0] }
     case 2:
-      return { publishedId: params[0], version: params[1] }
+      return { params, publishedId: params[0], version: params[1] }
     case 3:
-      return { authorUid: params[0], court: params[1], billId: params[2] }
+      return {
+        params,
+        authorUid: params[0],
+        court: params[1],
+        billId: params[2]
+      }
     case 4:
       return {
+        params,
         authorUid: params[0],
         court: params[1],
         billId: params[2],
@@ -127,12 +133,9 @@ export const getServerSideProps = wrapper.getServerSideProps(
 
     if (!docs) return notFound
     else if (!q.version) {
-      const baseUrl = ctx.resolvedUrl.split("?")[0]
+      const destination = [...q.params, docs.testimony.version].join("/")
       return {
-        redirect: {
-          destination: `${baseUrl}/${docs.testimony.version}`,
-          permanent: false
-        }
+        redirect: { destination, permanent: false }
       }
     } else if (q.version > docs.testimony.version) return notFound
 

--- a/pages/testimony/[...testimonyDetail].tsx
+++ b/pages/testimony/[...testimonyDetail].tsx
@@ -133,7 +133,11 @@ export const getServerSideProps = wrapper.getServerSideProps(
 
     if (!docs) return notFound
     else if (!q.version) {
-      const destination = [...q.params, docs.testimony.version].join("/")
+      const destination = [
+        "/testimony",
+        ...q.params,
+        docs.testimony.version
+      ].join("/")
       return {
         redirect: { destination, permanent: false }
       }


### PR DESCRIPTION
# Summary

- Fix bug where next router would get stuck in a redirect loop when clicking "More details" from the bill testimony list. Next 13 or 14 seems to change the `resolvedUrl` field so that it now includes query search parameters for each path parameter, which broke how we constructed redirect links. The update constructs the redirect link explicitly from the path parameters.
- Decrease batch size and increase timeout for scraping members. Member records are really big towards the end of the court because they include bill sponsor info. The api doesn't provide a way to request less info so we just give the functions more time to execute. Each request now gets a minute to complete, which should be plenty based  on my testing
- Set up a logs query and alert for timeouts from any of the scraper functions. Anyone that wants can be added to recieve the alerts [here](https://console.cloud.google.com/monitoring/alerting/policies/16805043925328419821?authuser=1&hl=en&project=digital-testimony-prod). The goal is to have no consistent alert. 

# Steps to test/reproduce


1. Go to a bill page
2. Scroll to the testimony list and click "More Details"
3. Your browser navigates to the testimony page
