### PR TITLE
[#1167] Add i18n translations to additional components from #1143

### DIFF
--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -134,14 +134,14 @@ const ResourcesLinks = () => {
 }
 
 const BrowseLinks = () => {
-  const { t } = useTranslation("footer")
+  const { t } = useTranslation("common")
   return (
     <>
       <StyledInternalLink href="/bills">
-        {t("links.browseBills")}
+        {t("navigation.browseBills")}
       </StyledInternalLink>
       <StyledInternalLink href="/testimony">
-        {t("links.browseTestimony")}
+        {t("navigation.browseTestimony")}
       </StyledInternalLink>
     </>
   )
@@ -163,7 +163,7 @@ const OurTeamLinks = () => {
 
 const AccountLinks = ({ authenticated, user, signOut }: PageFooterProps) => {
   const dispatch = useAppDispatch()
-  const { t } = useTranslation("footer")
+  const { t } = useTranslation(["common", "auth"])
   return (
     <>
       {authenticated ? (
@@ -171,17 +171,17 @@ const AccountLinks = ({ authenticated, user, signOut }: PageFooterProps) => {
           <StyledInternalLink
             href={`${user?.uid ? "/profile?id=" + user?.uid : "/profile"}`}
           >
-            {t("links.accountProfile")}
+            {t("navigation.accountProfile")}
           </StyledInternalLink>
           <StyledInternalLink handleClick={() => signOut()}>
-            {t("links.accountSignOut")}
+            {t("signOut", { ns: "auth" })}
           </StyledInternalLink>
         </>
       ) : (
         <StyledInternalLink
           handleClick={() => dispatch(authStepChanged("start"))}
         >
-          {t("links.accountSignIn")}
+          {t("signIn", { ns: "auth" })}
         </StyledInternalLink>
       )}
     </>
@@ -189,7 +189,7 @@ const AccountLinks = ({ authenticated, user, signOut }: PageFooterProps) => {
 }
 
 const LearnLinks = () => {
-  const { t } = useTranslation("footer")
+  const { t } = useTranslation(["footer", "common"])
   return (
     <>
       <StyledInternalLink href="/learn/writing-effective-testimony">
@@ -199,28 +199,28 @@ const LearnLinks = () => {
         {t("links.learnLegislators")}
       </StyledInternalLink>
       <StyledInternalLink href="/learn/additional-resources">
-        {t("links.learnResources")}
+        {t("navigation.additionalResources", { ns: "common" })}
       </StyledInternalLink>
     </>
   )
 }
 
 const AboutLinks = () => {
-  const { t } = useTranslation("footer")
+  const { t } = useTranslation("common")
   return (
     <>
       <StyledInternalLink href="/about/mission-and-goals">
-        {t("links.aboutMission")}
+        {t("navigation.missionAndGoals")}
       </StyledInternalLink>
       <StyledInternalLink href="/about/our-team">
-        {t("links.aboutTeam")}
+        {t("team")}
       </StyledInternalLink>
     </>
   )
 }
 
 const PageFooter = (props: PageFooterProps) => {
-  const { t } = useTranslation("footer")
+  const { t } = useTranslation(["footer", "common"])
   return (
     <FooterContainer
       fluid
@@ -239,11 +239,11 @@ const PageFooter = (props: PageFooterProps) => {
             <AccountLinks {...props} />
           </CustomDropdown>
 
-          <CustomDropdown title={t("headers.learn")}>
+          <CustomDropdown title={t("learn", { ns: "common" })}>
             <LearnLinks />
           </CustomDropdown>
 
-          <CustomDropdown title={t("headers.about")}>
+          <CustomDropdown title={t("about", { ns: "common" })}>
             <AboutLinks />
           </CustomDropdown>
 
@@ -251,7 +251,7 @@ const PageFooter = (props: PageFooterProps) => {
             <ResourcesLinks />
           </CustomDropdown>
 
-          <CustomDropdown title={t("headers.team")}>
+          <CustomDropdown title={t("team", { ns: "common" })}>
             <OurTeamLinks />
           </CustomDropdown>
         </Nav>
@@ -265,15 +265,15 @@ const PageFooter = (props: PageFooterProps) => {
           <AccountLinks {...props} />
         </Col>
         <Col>
-          <TextHeader>{t("headers.learn")}</TextHeader>
+          <TextHeader>{t("learn", { ns: "common" })}</TextHeader>
           <LearnLinks />
-          <TextHeader>{t("headers.about")}</TextHeader>
+          <TextHeader>{t("about", { ns: "common" })}</TextHeader>
           <AboutLinks />
         </Col>
         <Col>
           <TextHeader>{t("headers.resources")}</TextHeader>
           <ResourcesLinks />
-          <TextHeader>{t("headers.team")}</TextHeader>
+          <TextHeader>{t("team", { ns: "common" })}</TextHeader>
           <OurTeamLinks />
         </Col>
       </div>

--- a/components/LoadingPage.tsx
+++ b/components/LoadingPage.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "next-i18next"
 import Router from "next/router"
 import { FC, useEffect } from "react"
 import { Alert, Spinner } from "react-bootstrap"
@@ -25,16 +26,18 @@ export const LoadingPage = <Data,>({
 const Error: FC<React.PropsWithChildren<{ error: DataError }>> = ({
   error
 }) => {
+  const { t } = useTranslation("common")
   useEffect(() => console.error("Error loading page", error), [error])
-  let message = "There was a problem loading the page."
+  let message = t("loading.error.message")
   if (error.message) message = `${message} ${error.message}`
   return (
     <Container>
       <Alert variant="danger">
         <div>{message}</div>
         <div>
-          <Alert.Link onClick={() => Router.reload()}>Reload</Alert.Link> to try
-          again.
+          <Alert.Link onClick={() => Router.reload()}>
+            {t("loading.reload")}
+          </Alert.Link>
         </div>
       </Alert>
     </Container>

--- a/components/ProfileCard.tsx
+++ b/components/ProfileCard.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "next-i18next"
 import { FC } from "react"
 import styled from "styled-components"
 
@@ -12,6 +13,8 @@ export const ProfileCard: FC<React.PropsWithChildren<Props>> = ({
   profileImageSrc,
   joinDate
 }) => {
+  const { t } = useTranslation("profile")
+
   return (
     <Container>
       <Wrapper>
@@ -19,7 +22,7 @@ export const ProfileCard: FC<React.PropsWithChildren<Props>> = ({
           <img src={profileImageSrc} alt="profile image" />
         </ImageContainer>
         <ProfileName>{name}</ProfileName>
-        <JoinYear>Joined in {joinDate.getFullYear()}</JoinYear>
+        <JoinYear>{t("joinDate", { date: joinDate.getFullYear() })}</JoinYear>
       </Wrapper>
     </Container>
   )

--- a/components/ViewAttachment.tsx
+++ b/components/ViewAttachment.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "next-i18next"
 import { Testimony, usePublishedTestimonyAttachment } from "./db"
 import { External } from "./links"
 import styled from "styled-components"
@@ -14,8 +15,10 @@ export function ViewAttachment({ testimony }: { testimony?: Testimony }) {
 }
 
 const Open = ({ id }: { id: string }) => {
+  const { t } = useTranslation("testimony")
+
   const url = usePublishedTestimonyAttachment(id)
   return url ? (
-    <StyledExternal href={url}>View Attached Testimony PDF</StyledExternal>
+    <StyledExternal href={url}>{t("viewAttached")}</StyledExternal>
   ) : null
 }

--- a/components/buttons.tsx
+++ b/components/buttons.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useState } from "react"
 import { ButtonProps, ImageProps, SpinnerProps, Tooltip } from "react-bootstrap"
 import CopyToClipboard from "react-copy-to-clipboard"
+import { useTranslation } from "next-i18next"
 import styled from "styled-components"
 import { Button, Image, Overlay, OverlayTrigger, Spinner } from "./bootstrap"
 import { Internal } from "./links"
@@ -28,26 +29,29 @@ export const LoadingButton = ({
 }: ButtonProps & {
   loading?: boolean
   spinnerProps?: Partial<Omit<SpinnerProps, "as" | "role" | "aria-hidden">>
-}) => (
-  <Button {...restProps} disabled={loading || disabled}>
-    {loading ? (
-      <>
-        <Spinner
-          as="span"
-          animation="border"
-          size="sm"
-          role="status"
-          aria-hidden
-          className="me-2"
-          {...spinnerProps}
-        />
-        <span className="visually-hidden">Loading...</span>
-      </>
-    ) : null}
+}) => {
+  const { t } = useTranslation("common")
+  return (
+    <Button {...restProps} disabled={loading || disabled}>
+      {loading ? (
+        <>
+          <Spinner
+            as="span"
+            animation="border"
+            size="sm"
+            role="status"
+            aria-hidden
+            className="me-2"
+            {...spinnerProps}
+          />
+          <span className="visually-hidden">{t("loading.inProgress")}</span>
+        </>
+      ) : null}
 
-    {children}
-  </Button>
-)
+      {children}
+    </Button>
+  )
+}
 
 export const ImageButton = styled<
   Pick<ImageProps, "alt" | "src"> & { tooltip?: string; href?: string }

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -99,10 +99,7 @@ const TopNav: React.FC<React.PropsWithChildren<unknown>> = () => {
                     {t("navigation.browseTestimony")}
                   </NavLink>
 
-                  <NavDropdown
-                    className={"navLink-primary"}
-                    title={t("navigation.titleLearn")}
-                  >
+                  <NavDropdown className={"navLink-primary"} title={t("learn")}>
                     <NavDropdown.Item>
                       <NavLink
                         href="/learn/basics-of-testimony"
@@ -129,10 +126,7 @@ const TopNav: React.FC<React.PropsWithChildren<unknown>> = () => {
                     </NavDropdown.Item>
                   </NavDropdown>
 
-                  <NavDropdown
-                    className={"navLink-primary"}
-                    title={t("navigation.titleAbout")}
-                  >
+                  <NavDropdown className={"navLink-primary"} title={t("about")}>
                     <NavDropdown.Item>
                       <NavLink href="/about/faq-page" handleClick={closeNav}>
                         {t("navigation.faq")}
@@ -148,7 +142,7 @@ const TopNav: React.FC<React.PropsWithChildren<unknown>> = () => {
                     </NavDropdown.Item>
                     <NavDropdown.Item>
                       <NavLink href="/about/our-team" handleClick={closeNav}>
-                        {t("navigation.ourTeam")}
+                        {t("team")}
                       </NavLink>
                     </NavDropdown.Item>
                     <NavDropdown.Item>
@@ -168,7 +162,7 @@ const TopNav: React.FC<React.PropsWithChildren<unknown>> = () => {
 
                   <NavDropdown
                     className={"navLink-primary"}
-                    title={t("navigation.titleWhy")}
+                    title={t("whyUseMaple")}
                   >
                     <NavDropdown.Item>
                       <NavLink

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -1,4 +1,5 @@
 import Head from "next/head"
+import { useTranslation } from "next-i18next"
 import { useEffect, useState } from "react"
 import Image from "react-bootstrap/Image"
 import { useMediaQuery } from "usehooks-ts"
@@ -20,13 +21,15 @@ export const Layout: React.FC<React.PropsWithChildren<LayoutProps>> = ({
   title
 }) => {
   const { authenticated, user } = useAuth()
+  const { t } = useTranslation("common")
+  const formattedTitle = title
+    ? `${title} | ${t("maple_abbr")}: ${t("maple_fullName")}`
+    : `${t("maple_abbr")}: ${t("maple_fullName")}`
 
   return (
     <>
       <Head>
-        <title>{`${
-          title ? title + " | " : ""
-        }MAPLE: The Massachusetts Platform for Legislative Engagement`}</title>
+        <title>{formattedTitle}</title>
         <link rel="icon" href="/favicon.ico" />
       </Head>
       <div className={styles.pageContainer}>
@@ -49,6 +52,7 @@ const TopNav: React.FC<React.PropsWithChildren<unknown>> = () => {
   const isMobile = useMediaQuery("(max-width: 768px)")
   const [sticky, setSticky] = useState(false)
   const [isExpanded, setIsExpanded] = useState(false)
+  const { t } = useTranslation(["common", "auth"])
 
   const toggleNav = () => setIsExpanded(!isExpanded)
   const closeNav = () => setIsExpanded(false)
@@ -78,30 +82,33 @@ const TopNav: React.FC<React.PropsWithChildren<unknown>> = () => {
                     href="/"
                     handleClick={closeNav}
                   >
-                    Home
+                    {t("navigation.home")}
                   </NavLink>
                   <NavLink
                     className={"navLink-primary"}
                     href="/bills"
                     handleClick={closeNav}
                   >
-                    Browse Bills
+                    {t("navigation.browseBills")}
                   </NavLink>
                   <NavLink
                     className={"navLink-primary"}
                     href="/testimony"
                     handleClick={closeNav}
                   >
-                    Browse Testimony
+                    {t("navigation.browseTestimony")}
                   </NavLink>
 
-                  <NavDropdown className={"navLink-primary"} title={"Learn"}>
+                  <NavDropdown
+                    className={"navLink-primary"}
+                    title={t("navigation.titleLearn")}
+                  >
                     <NavDropdown.Item>
                       <NavLink
                         href="/learn/basics-of-testimony"
                         handleClick={closeNav}
                       >
-                        Learn About Testimony
+                        {t("navigation.learnAboutTestimony")}
                       </NavLink>
                     </NavDropdown.Item>
                     <NavDropdown.Item>
@@ -109,7 +116,7 @@ const TopNav: React.FC<React.PropsWithChildren<unknown>> = () => {
                         href="/learn/communicating-with-legislators"
                         handleClick={closeNav}
                       >
-                        Communicating with Legislators
+                        {t("navigation.communicatingWithLegislators")}
                       </NavLink>
                     </NavDropdown.Item>
                     <NavDropdown.Item>
@@ -117,15 +124,18 @@ const TopNav: React.FC<React.PropsWithChildren<unknown>> = () => {
                         href="/learn/additional-resources"
                         handleClick={closeNav}
                       >
-                        Additional Resources
+                        {t("navigation.additionalResources")}
                       </NavLink>
                     </NavDropdown.Item>
                   </NavDropdown>
 
-                  <NavDropdown className={"navLink-primary"} title={"About"}>
+                  <NavDropdown
+                    className={"navLink-primary"}
+                    title={t("navigation.titleAbout")}
+                  >
                     <NavDropdown.Item>
                       <NavLink href="/about/faq-page" handleClick={closeNav}>
-                        FAQ
+                        {t("navigation.faq")}
                       </NavLink>
                     </NavDropdown.Item>
                     <NavDropdown.Item>
@@ -133,12 +143,12 @@ const TopNav: React.FC<React.PropsWithChildren<unknown>> = () => {
                         href="/about/mission-and-goals"
                         handleClick={closeNav}
                       >
-                        Our Mission &amp; Goals
+                        {t("navigation.missionAndGoals")}
                       </NavLink>
                     </NavDropdown.Item>
                     <NavDropdown.Item>
                       <NavLink href="/about/our-team" handleClick={closeNav}>
-                        Our Team
+                        {t("navigation.ourTeam")}
                       </NavLink>
                     </NavDropdown.Item>
                     <NavDropdown.Item>
@@ -146,26 +156,26 @@ const TopNav: React.FC<React.PropsWithChildren<unknown>> = () => {
                         href="/about/support-maple"
                         handleClick={closeNav}
                       >
-                        How to Support MAPLE
+                        {t("navigation.supportMaple")}
                       </NavLink>
                     </NavDropdown.Item>
                     <NavDropdown.Item>
                       <NavLink href="/policies" handleClick={closeNav}>
-                        Privacy Policy & Code of Conduct
+                        {t("navigation.privacyAndConduct")}
                       </NavLink>
                     </NavDropdown.Item>
                   </NavDropdown>
 
                   <NavDropdown
                     className={"navLink-primary"}
-                    title={"Why Use MAPLE"}
+                    title={t("navigation.titleWhy")}
                   >
                     <NavDropdown.Item>
                       <NavLink
                         href="/why-use-maple/for-individuals"
                         handleClick={closeNav}
                       >
-                        For Individuals
+                        {t("navigation.forIndividuals")}
                       </NavLink>
                     </NavDropdown.Item>
                     <NavDropdown.Item>
@@ -173,7 +183,7 @@ const TopNav: React.FC<React.PropsWithChildren<unknown>> = () => {
                         href="/why-use-maple/for-orgs"
                         handleClick={closeNav}
                       >
-                        For Organizations
+                        {t("navigation.forOrganizations")}
                       </NavLink>
                     </NavDropdown.Item>
                     <NavDropdown.Item>
@@ -181,7 +191,7 @@ const TopNav: React.FC<React.PropsWithChildren<unknown>> = () => {
                         href="/why-use-maple/for-legislators"
                         handleClick={closeNav}
                       >
-                        For Legislators
+                        {t("navigation.forLegislators")}
                       </NavLink>
                     </NavDropdown.Item>
                   </NavDropdown>
@@ -194,7 +204,7 @@ const TopNav: React.FC<React.PropsWithChildren<unknown>> = () => {
                         void signOutAndRedirectToHome()
                       }}
                     >
-                      Sign Out
+                      {t("signOut", { ns: "auth" })}
                     </NavLink>
                   )}
                 </Nav>

--- a/components/links.tsx
+++ b/components/links.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "next-i18next"
 import Link from "next/link"
 import { forwardRef, PropsWithChildren } from "react"
 import { CurrentCommittee } from "../functions/src/bills/types"

--- a/components/links.tsx
+++ b/components/links.tsx
@@ -1,10 +1,10 @@
-import { useTranslation } from "next-i18next"
 import Link from "next/link"
 import { forwardRef, PropsWithChildren } from "react"
 import { CurrentCommittee } from "../functions/src/bills/types"
 import { Testimony } from "components/db/testimony"
 import { Bill, MemberContent } from "./db"
 import { formatBillId } from "./formatting"
+import { TFunction } from "next-i18next"
 
 type LinkProps = PropsWithChildren<{ href: string; className?: string }>
 
@@ -103,10 +103,11 @@ export function committeeURL(CommitteeCode: string) {
 }
 
 export function committeeLink(
-  currentCommitteeContent: CurrentCommittee | undefined
+  currentCommitteeContent: CurrentCommittee | undefined,
+  t: TFunction
 ) {
   if (currentCommitteeContent === undefined) {
-    return <p>Bill not currently in committee</p>
+    return <p>{t("notInCommittee")}</p>
   }
 
   const { id, name } = currentCommitteeContent
@@ -121,12 +122,10 @@ export function memberLink(member: MemberContent) {
   return <External href={memberURL(member)}>{member.Name}</External>
 }
 
-export const twitterShareLink = (publication: Testimony) => {
+export const twitterShareLink = (publication: Testimony, t: TFunction) => {
   const link = siteUrl(maple.testimony({ publishedId: publication.id })),
     billNumber = formatBillId(publication.billId),
-    tweet = encodeURIComponent(
-      `I provided testimony on Bill ${billNumber}. See ${link} for details.`
-    ),
+    tweet = encodeURIComponent(t("link.tweetContent", { billNumber, link })),
     tweetUrl = `https://twitter.com/intent/tweet?text=${tweet}`
 
   return tweetUrl

--- a/components/publish/panel/YourTestimony.tsx
+++ b/components/publish/panel/YourTestimony.tsx
@@ -8,6 +8,7 @@ import { TestimonyPreview } from "../TestimonyPreview"
 import { EditTestimonyButton } from "./EditTestimonyButton"
 import { ArchiveTestimonyButton } from "./ArchiveTestimonyButton"
 import { ArchiveTestimonyConfirmation } from "./ArchiveTestimonyConfirmation"
+import { useTranslation } from "next-i18next"
 
 export const YourTestimony = () => {
   const synced = usePublishState().sync === "synced"
@@ -107,10 +108,15 @@ const Cta = styled(Button).attrs({ variant: "light" })`
 `
 
 const TwitterButton = (props: ClsProps) => {
+  const { t } = useTranslation("testimony")
   const { publication } = usePublishState()
   return publication ? (
-    <External as={Cta as any} href={twitterShareLink(publication)} {...props}>
-      Tweet Your Published Testimony
+    <External
+      as={Cta as any}
+      href={twitterShareLink(publication, t)}
+      {...props}
+    >
+      {t("link.twitter")}
     </External>
   ) : null
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -38,6 +38,7 @@
     "supportMaple": "How to Support MAPLE"
   },
   "newcomer" : "New to MAPLE? For extra support, check",
+  "notInCommittee": "Bill not currently in committee",
   "orgs": "Organizations",
   "pending_upgrade_warning": {
     "header": "Organization Request In Progress",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -18,4 +18,31 @@
   "pending_upgrade_warning": {
     "header": "Organization Request In Progress",
     "content": "Your request to be upgraded to an organization is currently in progress. You will be notified by email when your request has been reviewed."
-  }}
+  },
+  "loading": {
+    "inProgress": "Loading...",
+    "error": {
+      "message": "There was a problem loading the page."
+    },
+    "reload": "Reload to try again"
+  },
+  "navigation": {
+    "additionalResources": "Additional Resources",
+    "browseBills": "Browse Bills",
+    "browseTestimony": "Browse Testimony",
+    "communicatingWithLegislators": "Communicating with Legislators",
+    "faq": "FAQ",
+    "forIndividuals": "For Individuals",
+    "forLegislators": "For Legislators",
+    "forOrganizations": "For Organizations",
+    "home": "Home",
+    "learnAboutTestimony": "Learn About Testimony",
+    "missionAndGoals": "Our Mission & Goals",
+    "ourTeam": "Our Team",
+    "privacyAndConduct": "Privacy Policy & Code of Conduct",
+    "supportMaple": "How to Support MAPLE",
+    "titleAbout": "About",
+    "titleLearn": "Learn",
+    "titleWhy": "Why Use MAPLE"
+  },
+}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1,24 +1,16 @@
 {
-  "maple_fullName": "Massachusetts Platform for Legislative Engagement",
-  "maple_abbr": "MAPLE",
-  "let_your_voice_be_heard": "Let your voice be heard!",
-  "short_description": "MAPLE makes it easy for anyone to view and submit testimony to the Massachusetts Legislature about the bills that will shape our future.",
-  "browse_bills": "browse bills",
-  "logInSignUp": "Log in / Sign up",
+  "about": "About",
   "back_to_bills": "back to list of bills",
+  "browse_bills": "browse bills",
   "button":{
     "follow" : "Follow",
     "following" : "Following",
     "followed" : "Followed"
   },
-  "orgs": "Organizations",
-  "newcomer" : "New to MAPLE? For extra support, check",
   "calendar": "Our Calendar",
   "joinTraining": "and join an upcoming training session!",
-  "pending_upgrade_warning": {
-    "header": "Organization Request In Progress",
-    "content": "Your request to be upgraded to an organization is currently in progress. You will be notified by email when your request has been reviewed."
-  },
+  "learn": "Learn",
+  "let_your_voice_be_heard": "Let your voice be heard!",
   "loading": {
     "inProgress": "Loading...",
     "error": {
@@ -26,7 +18,11 @@
     },
     "reload": "Reload to try again"
   },
+  "logInSignUp": "Log in / Sign up",
+  "maple_abbr": "MAPLE",
+  "maple_fullName": "Massachusetts Platform for Legislative Engagement",
   "navigation": {
+    "accountProfile": "Profile",
     "additionalResources": "Additional Resources",
     "browseBills": "Browse Bills",
     "browseTestimony": "Browse Testimony",
@@ -38,11 +34,16 @@
     "home": "Home",
     "learnAboutTestimony": "Learn About Testimony",
     "missionAndGoals": "Our Mission & Goals",
-    "ourTeam": "Our Team",
     "privacyAndConduct": "Privacy Policy & Code of Conduct",
-    "supportMaple": "How to Support MAPLE",
-    "titleAbout": "About",
-    "titleLearn": "Learn",
-    "titleWhy": "Why Use MAPLE"
+    "supportMaple": "How to Support MAPLE"
   },
+  "newcomer" : "New to MAPLE? For extra support, check",
+  "orgs": "Organizations",
+  "pending_upgrade_warning": {
+    "header": "Organization Request In Progress",
+    "content": "Your request to be upgraded to an organization is currently in progress. You will be notified by email when your request has been reviewed."
+  },
+  "short_description": "MAPLE makes it easy for anyone to view and submit testimony to the Massachusetts Legislature about the bills that will shape our future.",
+  "team": "Our Team",
+  "whyUseMaple": "Why Use MAPLE"
 }

--- a/public/locales/en/footer.json
+++ b/public/locales/en/footer.json
@@ -3,22 +3,11 @@
     "follow": "Follow MAPLE",
     "browse": "Browse",
     "account": "Account",
-    "learn": "Learn",
-    "about": "About",
-    "resources": "Resources",
-    "team": "Our Team"
+    "resources": "Resources"
   },
   "links": {
-    "browseBills": "Browse Bills",
-    "browseTestimony": "Browse Testimony",
-    "accountSignIn": "Sign In",
-    "accountSignOut": "Sign Out",
-    "accountProfile": "Profile",
     "learnWriting": "Writing Effective Testimony",
     "learnLegislators": "Contacting Legislators",
-    "learnResources": "Additional Resources",
-    "aboutMission": "Our Mission & Goals",
-    "aboutTeam": "Our Team",
     "resourcesLegislators": "Find your Legislators",
     "resourcesGitHub": "MAPLE on GitHub",
     "resourcesOpenCollective": "MAPLE OpenCollective",

--- a/public/locales/en/profile.json
+++ b/public/locales/en/profile.json
@@ -4,6 +4,7 @@
   "user": "User",
   "noUser": "no user",
   "anonymousUser": "Anonymous User",
+  "joinDate": "Joined in {{date}}",
   "button":{
     "editProfile": "Edit\u00A0Profile",
     "notficationFrequencyDropdown": "open envelope with letter, toggles update frequency options",

--- a/public/locales/en/testimony.json
+++ b/public/locales/en/testimony.json
@@ -1,4 +1,8 @@
 {
+  "link": {
+    "tweetContent": "I provided testimony on Bill {{billNumber}}. See {{link}} for details.",
+    "twitter": "Tweet Your Published Testimony"
+  },
   "testimonyDetail": {
     "what": "What",
     "says": "says",

--- a/public/locales/en/testimony.json
+++ b/public/locales/en/testimony.json
@@ -76,6 +76,7 @@
   "userInfoHeader": {
     "edited": "Edited"
   },
+  "viewAttached": "View Attached Testimony PDF",
   "viewTestimony": {
     "showing": "Showing",
     "showing1": "Showing 1 - ",


### PR DESCRIPTION
# Summary

This PR address issue #1167 

Translations added to the following files:
`components/buttons.tsx`
`components/layout.tsx`
`components/links.tsx`
`components/LoadingPage.tsx`
`components/ProfileCard.tsx`
`components/ViewAttachment.tsx`

# Checklist

- [x] On the frontend, I've made my strings translate-able.
- [ ] If I've added shared components, I've added a storybook story.
- [ ] I've made pages responsive and look good on mobile.

# Steps to test/reproduce

_For each feature or bug fix, create a step by step list for how a reviewer can test it out. E.g.:_

1. Go to the home page
2. Look at the navigation item, footer links, tab title
3. Make sure all text displays English text 

Some components changed aren't currently being used, so the translations weren't manually verifiable.