### PR TITLE
Switch to builder callback notation for redux

### DIFF
--- a/components/testimony/TestimonyDetailPage/testimonyDetailSlice.ts
+++ b/components/testimony/TestimonyDetailPage/testimonyDetailSlice.ts
@@ -1,4 +1,4 @@
-import { createSlice, PayloadAction } from "@reduxjs/toolkit"
+import { AnyAction, createSlice, PayloadAction } from "@reduxjs/toolkit"
 import { Bill, Profile, Testimony } from "components/db"
 import { TestimonyQuery } from "components/db/api"
 import { createAppSelector, useAppSelector } from "components/hooks"
@@ -46,10 +46,10 @@ export const slice = createSlice({
       state.selectedVersion = action.payload
     }
   },
-  extraReducers: {
-    [HYDRATE]: (state, action) => {
+  extraReducers: builder => {
+    builder.addCase(HYDRATE, (state, action: AnyAction) => {
       Object.assign(state, action.payload[slice.name])
-    }
+    })
   }
 })
 


### PR DESCRIPTION
# Summary

This PR updates the lone redux reducer not using the newer "builder callback" notation to use it. The old reducer object notation is deprecated and was logging a warning in the console. 

Resolves #1487 

# Checklist

- [na] On the frontend, I've made my strings translate-able.
- [na] If I've added shared components, I've added a storybook story.
- [na] I've made pages responsive and look good on mobile.

# Screenshots

The `extraReducers` warning no longer appears:
<img width="1394" alt="Screenshot 2024-03-08 at 10 38 40 PM" src="https://github.com/codeforboston/maple/assets/2694761/20c31ce8-19a2-4fd8-94cc-a75a2b269b4b">

# Known issues

N/A

# Steps to test/reproduce

1. Go to the home page
2. See that everything renders as expected
3. Open the console
4. See that there is no warning about the deprecated extraBuilders notation
