### PR TITLE
Feature Flag Overrides

### DIFF
--- a/components/ProfilePage/ProfileButtons.tsx
+++ b/components/ProfilePage/ProfileButtons.tsx
@@ -8,6 +8,7 @@ import { Story } from "stories/atoms/BaseButton.stories"
 import { Internal } from "components/links"
 import { useProfile, ProfileHook } from "components/db"
 import { FollowButton } from "./FollowButton"
+import { useFlags } from "components/featureFlags"
 
 export const StyledButton = styled(Button).attrs(props => ({
   className: `col-12 d-flex align-items-center justify-content-center py-3 text-nowrap`,
@@ -89,5 +90,8 @@ export function ProfileButtonsUser({
   )
 }
 export function ProfileButtonsOrg({ isUser }: { isUser: boolean }) {
-  return <>{isUser ? <EditProfileButton /> : <FollowButton />}</>
+  const { followOrg } = useFlags()
+  return (
+    <>{isUser ? <EditProfileButton /> : followOrg ? <FollowButton /> : null}</>
+  )
 }

--- a/components/TestimonyCard/TestimonyItem.tsx
+++ b/components/TestimonyCard/TestimonyItem.tsx
@@ -19,7 +19,7 @@ import styles from "./ViewTestimony.module.css"
 import { UseAsyncReturn } from "react-async-hook"
 import { useTranslation } from "next-i18next"
 import { trimContent } from "components/TestimonyCallout/TestimonyCallout"
-import { flags } from "components/featureFlags"
+import { useFlags } from "components/featureFlags"
 
 const FooterButton = styled(Button)`
   margin: 0;
@@ -115,6 +115,8 @@ export const TestimonyItem = ({
 
   const [showConfirm, setShowConfirm] = useState(false)
   const { deleteTestimony } = usePublishService() ?? {}
+
+  const { reportTestimony } = useFlags()
 
   const { t } = useTranslation("testimony")
 
@@ -243,7 +245,7 @@ export const TestimonyItem = ({
             </>
           )}
           {/* report */}
-          {flags().reportTestimony && (
+          {reportTestimony && (
             <Col xs="auto">
               <FooterButton variant="link" onClick={() => setIsReporting(true)}>
                 Report

--- a/components/bill/BillDetails.tsx
+++ b/components/bill/BillDetails.tsx
@@ -1,4 +1,4 @@
-import { flags } from "components/featureFlags"
+import { useFlags } from "components/featureFlags"
 import {
   collection,
   deleteDoc,
@@ -45,6 +45,7 @@ export const BillDetails = ({ bill }: BillProps) => {
   const { t } = useTranslation("common")
 
   const isPendingUpgrade = useAuth().claims?.role === "pendingUpgrade"
+  const flags = useFlags()
 
   return (
     <>
@@ -77,7 +78,7 @@ export const BillDetails = ({ bill }: BillProps) => {
             </Row>
             <Row className="mb-4">
               <Col xs={12} className="d-flex justify-content-end">
-                {flags().notifications && <FollowBillButton bill={bill} />}
+                {flags.notifications && <FollowBillButton bill={bill} />}
               </Col>
             </Row>
           </>
@@ -88,7 +89,7 @@ export const BillDetails = ({ bill }: BillProps) => {
             </Col>
             <Col xs={6} className="d-flex justify-content-end">
               <Styled>
-                {flags().notifications && <FollowBillButton bill={bill} />}
+                {flags.notifications && <FollowBillButton bill={bill} />}
               </Styled>
             </Col>
           </Row>
@@ -102,7 +103,7 @@ export const BillDetails = ({ bill }: BillProps) => {
           <Col md={8}>
             <Sponsors bill={bill} className="mt-4 pb-1" />
             <BillTestimonies bill={bill} className="mt-4" />
-            {flags().lobbyingTable && (
+            {flags.lobbyingTable && (
               <LobbyingTable bill={bill} className="mt-4 pb-1" />
             )}
           </Col>
@@ -113,7 +114,7 @@ export const BillDetails = ({ bill }: BillProps) => {
               className="bg-secondary d-flex justify-content-center mt-4 pb-1 text-light"
             />
             <TestimonyFormPanel bill={bill} />
-            {flags().billTracker && (
+            {flags.billTracker && (
               <BillTrackerConnectedView bill={bill} className="mt-4" />
             )}
           </Col>

--- a/components/featureFlags.ts
+++ b/components/featureFlags.ts
@@ -1,3 +1,4 @@
+import { useRouter } from "next/router"
 import { z } from "zod"
 
 export const FeatureFlags = z.object({
@@ -63,3 +64,15 @@ const values = FeatureFlags.parse(defaults[envName])
 
 // Add a function call of indirection to allow reloading values in the future
 export const flags = () => values
+
+export function useFlags() {
+  const router = useRouter()
+  const { query } = router
+
+  return FeatureFlags.keyof().options.reduce((acc, flagName) => {
+    if (flagName in query) {
+      acc[flagName] = query[flagName] === "enabled"
+    }
+    return acc
+  }, FeatureFlags.parse(defaults[envName]))
+}

--- a/components/search/testimony/TestimonyHit.tsx
+++ b/components/search/testimony/TestimonyHit.tsx
@@ -7,7 +7,7 @@ import { formatBillId } from "components/formatting"
 import { useBill } from "components/db/bills"
 import { FollowOrgButton } from "components/shared/FollowButton"
 import { Image } from "react-bootstrap"
-import { flags } from "components/featureFlags"
+import { useFlags } from "components/featureFlags"
 
 export const TestimonyHit = ({ hit }: { hit: Hit<Testimony> }) => {
   const url = maple.testimony({ publishedId: hit.id })
@@ -38,6 +38,8 @@ const TestimonyResult = ({ hit }: { hit: Hit<Testimony> }) => {
     ) : (
       hit.authorDisplayName
     )
+  const { followOrg } = useFlags()
+
   return (
     <div
       style={{
@@ -64,9 +66,7 @@ const TestimonyResult = ({ hit }: { hit: Hit<Testimony> }) => {
         <span style={{ flexGrow: 1 }}>
           <b>Written by {writtenBy}</b>
         </span>
-        {flags().followOrg && isOrg && (
-          <FollowOrgButton profileId={hit.authorUid} />
-        )}
+        {followOrg && isOrg && <FollowOrgButton profileId={hit.authorUid} />}
       </div>
       <hr />
       <div style={{ display: "flex", alignItems: "center" }}>

--- a/components/search/useRouting.tsx
+++ b/components/search/useRouting.tsx
@@ -11,7 +11,18 @@ const pathToSearchState = (path: string) =>
 
 const searchStateToUrl = (searchState: UiState) => {
   const base = window.location.pathname
-  const query = qs.stringify(searchState)
+
+  const flagQueries = Object.fromEntries(
+    Object.entries(qs.parse(window.location.search.slice(1))).filter(
+      ([key]) => !Object.keys(searchState).includes(key)
+    )
+  )
+
+  const query = qs.stringify({
+    ...searchState,
+    ...flagQueries
+  })
+
   return query ? `${base}?${query}` : base
 }
 

--- a/components/testimony/TestimonyDetailPage/PolicyActions.tsx
+++ b/components/testimony/TestimonyDetailPage/PolicyActions.tsx
@@ -1,5 +1,5 @@
 import { Card, ListItem, ListItemProps } from "components/Card"
-import { flags } from "components/featureFlags"
+import { useFlags } from "components/featureFlags"
 import { formatBillId } from "components/formatting"
 import { formUrl } from "components/publish"
 import { isNotNull } from "components/utils"
@@ -26,9 +26,10 @@ export const PolicyActions: FC<React.PropsWithChildren<PolicyActionsProps>> = ({
 }) => {
   const { bill } = useCurrentTestimonyDetails(),
     billLabel = formatBillId(bill.id)
+  const { notifications } = useFlags()
 
   const items: ReactElement[] = []
-  if (flags().notifications)
+  if (notifications)
     items.push(
       <PolicyActionItem
         onClick={() => window.alert("TODO")} // TODO: add follow action here

--- a/components/testimony/TestimonyDetailPage/TestimonyDetail.tsx
+++ b/components/testimony/TestimonyDetailPage/TestimonyDetail.tsx
@@ -4,7 +4,7 @@ import { FC, ImgHTMLAttributes } from "react"
 import styled from "styled-components"
 import { useCurrentTestimonyDetails } from "./testimonyDetailSlice"
 import { TestimonyContent } from "../TestimonyContent"
-import { flags } from "components/featureFlags"
+import { useFlags } from "components/featureFlags"
 import { useTranslation } from "next-i18next"
 
 const Container = styled.div`
@@ -16,9 +16,8 @@ const Container = styled.div`
 
 const Testimony = styled(props => {
   const { revision, authorTitle } = useCurrentTestimonyDetails()
-  const previous = flags().testimonyDiffing
-    ? revision.previous?.content
-    : undefined
+  const { testimonyDiffing } = useFlags()
+  const previous = testimonyDiffing ? revision.previous?.content : undefined
 
   const { t } = useTranslation("testimony")
 


### PR DESCRIPTION
# Summary

This PR adds support for overriding feature flag values by setting a query parameter (e.g. `?myFlagName=enabled` will force a flag on). This should work for most use cases (barring potentially SSG) and should make testing different flag states much easier.

This also make InstantSearch ignore unrelated query parameters. We need this to keep the search URL updates from obliterating our feature flag overrides (there are no flags on the search pages yet, but it seemed like too sharp of an edge to put off handling).

#1503 

# Checklist

- [na] On the frontend, I've made my strings translate-able.
- [na] If I've added shared components, I've added a storybook story.
- [na] I've made pages responsive and look good on mobile.

# Screenshots

N/A

# Known issues

N/A

# Steps to test/reproduce

1. Go to a page with a known flag-gated feature (like the Bill Tracker or Follow Org button)
1. Set the flag as a query param with values of "enabled"/"disabled to test the different states
2. Verify that the feature appears when the flag is enabled, disappears when it is disabled, and has the default behavior when no flag query param is set

Likely also worth testing the bill/testimony search pages - there should be no change in the functionality there

