### PR TITLE
Bootstrap Migration Divider 

### DIFF
--- a/components/Divider/Divider.module.css
+++ b/components/Divider/Divider.module.css
@@ -1,4 +1,0 @@
-.line {
-  height: 2px !important;
-  opacity: 1;
-}

--- a/components/Divider/Divider.tsx
+++ b/components/Divider/Divider.tsx
@@ -2,8 +2,13 @@ import clsx from "clsx"
 import React from "react"
 import type { RowProps } from "react-bootstrap"
 import { Col, Row } from "../bootstrap"
-import styles from "./Divider.module.css"
+import styled from "styled-components"
 
+
+const Line = styled('hr')`
+  height: 2px !important;
+  opacity: 1;
+`
 export default function Divider({
   children,
   className,
@@ -12,11 +17,11 @@ export default function Divider({
   return (
     <Row {...restProps} className={clsx("text-secondary", className)}>
       <Col>
-        <hr className={styles.line} />
+        <Line />
       </Col>
       <Col className="col-auto fs-5">{children}</Col>
       <Col>
-        <hr className={styles.line} />
+        <Line />
       </Col>
     </Row>
   )

--- a/components/Divider/Divider.tsx
+++ b/components/Divider/Divider.tsx
@@ -4,8 +4,7 @@ import type { RowProps } from "react-bootstrap"
 import { Col, Row } from "../bootstrap"
 import styled from "styled-components"
 
-
-const Line = styled('hr')`
+const Line = styled("hr")`
   height: 2px !important;
   opacity: 1;
 `


### PR DESCRIPTION
# Summary
remove divider css module, migrate styling to Divider file

Note: most of the Dividers used in the project are ad hoc styled components and do not reference a css module


