### PR TITLE
Removing defunct flags

### DIFF
--- a/components/TestimonyCard/TestimonyItem.tsx
+++ b/components/TestimonyCard/TestimonyItem.tsx
@@ -19,7 +19,6 @@ import styles from "./ViewTestimony.module.css"
 import { UseAsyncReturn } from "react-async-hook"
 import { useTranslation } from "next-i18next"
 import { trimContent } from "components/TestimonyCallout/TestimonyCallout"
-import { useFlags } from "components/featureFlags"
 
 const FooterButton = styled(Button)`
   margin: 0;
@@ -115,8 +114,6 @@ export const TestimonyItem = ({
 
   const [showConfirm, setShowConfirm] = useState(false)
   const { deleteTestimony } = usePublishService() ?? {}
-
-  const { reportTestimony } = useFlags()
 
   const { t } = useTranslation("testimony")
 
@@ -245,13 +242,11 @@ export const TestimonyItem = ({
             </>
           )}
           {/* report */}
-          {reportTestimony && (
-            <Col xs="auto">
-              <FooterButton variant="link" onClick={() => setIsReporting(true)}>
-                Report
-              </FooterButton>
-            </Col>
-          )}
+          <Col xs="auto">
+            <FooterButton variant="link" onClick={() => setIsReporting(true)}>
+              Report
+            </FooterButton>
+          </Col>
         </Row>
       </Stack>
 

--- a/components/featureFlags.ts
+++ b/components/featureFlags.ts
@@ -11,11 +11,7 @@ export const FeatureFlags = z.object({
   /** Follow button for organizations */
   followOrg: z.boolean().default(false),
   /** Lobbying Table */
-  lobbyingTable: z.boolean().default(false),
-  /** Submitting testimony fron mobile views */
-  mobileTestimony: z.boolean().default(false),
-  /** Report testimony */
-  reportTestimony: z.boolean().default(false)
+  lobbyingTable: z.boolean().default(false)
 })
 
 export type FeatureFlags = z.infer<typeof FeatureFlags>
@@ -33,27 +29,21 @@ const defaults: Record<Env, FeatureFlags> = {
     notifications: true,
     billTracker: true,
     followOrg: true,
-    lobbyingTable: false,
-    mobileTestimony: false,
-    reportTestimony: true
+    lobbyingTable: false
   },
   production: {
     testimonyDiffing: false,
     notifications: false,
     billTracker: false,
     followOrg: false,
-    lobbyingTable: false,
-    mobileTestimony: false,
-    reportTestimony: true
+    lobbyingTable: false
   },
   test: {
     testimonyDiffing: false,
     notifications: false,
     billTracker: false,
     followOrg: false,
-    lobbyingTable: false,
-    mobileTestimony: false,
-    reportTestimony: false
+    lobbyingTable: false
   }
 }
 


### PR DESCRIPTION
# Summary

Following up on our hack night discussion on flagged code, this PR removes two flags: `mobileTestimony` (which is used nowhere) and `reportTestimony` (which has been turned on in production for some time and no longer needs to be flagged).

# Checklist

- [na] On the frontend, I've made my strings translate-able.
- [na] If I've added shared components, I've added a storybook story.
- [na] I've made pages responsive and look good on mobile.

# Screenshots

N/A (No visible change)

# Known issues

N/A

# Steps to test/reproduce

1. Go to a testimony detail page
1. Verify that the "Report Testimony" button shows up
