### PR TITLE
Migrating AlertCardBody to Bootstrap

### DIFF
--- a/components/AlertCard/AlertCard.module.css
+++ b/components/AlertCard/AlertCard.module.css
@@ -1,7 +1,0 @@
-.body {
-  font-family: Nunito;
-  font-style: normal;
-  font-weight: 500;
-  font-size: 18px;
-  line-height: 25px;
-}

--- a/components/AlertCard/AlertCardBody.tsx
+++ b/components/AlertCard/AlertCardBody.tsx
@@ -1,6 +1,5 @@
 import { ReactElement } from "react"
 import CardBootstrap from "react-bootstrap/Card"
-import styles from "./AlertCard.module.css"
 
 interface AlertCardBodyProps {
   imgSrc?: string
@@ -14,7 +13,7 @@ export const AlertCardBody = (props: AlertCardBodyProps) => {
     <div>
       {imgSrc && <img src={imgSrc} width="100%" alt={imgAltTxt}></img>}
       <CardBootstrap.Body>
-        <CardBootstrap.Text className={styles.body}>{text}</CardBootstrap.Text>
+        <CardBootstrap.Text>{text}</CardBootstrap.Text>
       </CardBootstrap.Body>
     </div>
   )


### PR DESCRIPTION
# Summary

This PR just removes the CSS Module styles from the AlertCardBody component (as per #1450 )

This component is part of the newsfeed that isn't currently used, and the only styles it set seem to be default styles, so I think we're safe to just remove them entirely. We'll definitely revisit styling here as we continue our follows/notifications work, but this will set us right to close out the bootstrap migration.

# Checklist

- [na] On the frontend, I've made my strings translate-able.
- [na] If I've added shared components, I've added a storybook story.
- [na] I've made pages responsive and look good on mobile.

# Screenshots

N/A (Not currently in use, no visible change)

# Known issues

N/A

# Steps to test/reproduce

N/A
