### PR TITLE
[1508] Add Playwright for e2e testing (attempt 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,9 +4,16 @@
 /node_modules
 /.pnp
 .pnp.js
+.yarn*
 
 # testing
 /coverage
+
+# testing - playwright e2e
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
 
 .next/
 .eslintcache

--- a/README.md
+++ b/README.md
@@ -68,13 +68,24 @@ git pull upstream main
 - `yarn dev:up:detach`: Run the application, and keep it running once you stop this command.
 - `yarn dev:down`: Stop the application.
 - `yarn dev:update`: Update the application images. Run this whenever dependencies in `package.json` change.
-- `yarn test:integration [--watch] [-t testNamePattern] [my/feature.test.ts]`: Run integration tests in `components/` and `tests/integration/`. These tests run against the full local application -- start it with `yarn up`. You can use `--watch` to rerun your tests as you change them and filter by test name and file.
 
 Install the [Redux DevTools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd) and [React DevTools](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi) browser extensions if you're developing frontend
 
 ## Contributing Backend Features to Dev/Prod:
 
 - If you are developing backend features involving only Next.js API routes and need to deploy them to the Dev site, download [Google application credentials for the dev project](https://console.firebase.google.com/u/0/project/digital-testimony-dev/settings/serviceaccounts/adminsdk) (you will need to be added as an editor of the project). Then, run `export GOOGLE_APPLICATION_CREDENTIALS=path-to-credentials.json` before running `yarn dev`. This is necessary to authenticate the Firebase Admin SDK. The same would apply to production.
+
+## Testing
+
+MAPLE uses Jest for unit and integration testing, and Playwright for e2e testing.
+
+To start running tests, use one of the following commands:
+
+- `yarn test:integration [--watch] [-t testNamePattern] [my/feature.test.ts]`: Run integration tests in `components/` and `tests/integration/`. These tests run against the full local application -- start it with `yarn up`. You can use `--watch` to rerun your tests as you change them and filter by test name and file.
+- `yarn test:e2e`: Run e2e tests in `tests/e2e` with the Playwright UI
+- `yarn test:e2e:headless`: Run e2e tests in `tests/e2e` headless (no UI)
+
+For an introduction on how to write e2e tests with Playwright, go to the [Playwright docs](https://playwright.dev/docs/writing-tests). An example of an e2e test can be found in `tests/e2e/homepage.spec.ts`.
 
 ## Code Formatting and Linting
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "lint:fix": "next lint --fix",
     "serve": "firebase emulators:start --only hosting",
     "start": "next start",
+    "test:e2e": "playwright test --ui",
+    "test:e2e:headless": "playwright test",
     "test:integration": "jest -c tests/jest.integration.config.ts -w 1",
     "test:integration-ci": "node scripts/test-integration-ci.js",
     "test:system": "jest -c tests/jest.system.config.ts",
@@ -46,7 +48,8 @@
     "backfill-user-nf": "ts-node -P tsconfig.script.json scripts/firebase-admin/backfillNotificationFrequency.ts --swc"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=16",
+    "yarn": "1.22.22"
   },
   "browserslist": {
     "production": [
@@ -130,6 +133,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.18.13",
+    "@playwright/test": "^1.43.1",
     "@storybook/addon-actions": "^7.6.4",
     "@storybook/addon-essentials": "^7.6.4",
     "@storybook/addon-interactions": "^7.6.4",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "engines": {
     "node": ">=16",
-    "yarn": "1.22.19"
+    "yarn": "^1.22.19"
   },
   "browserslist": {
     "production": [

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   },
   "engines": {
     "node": ">=16",
-    "yarn": "1.22.22"
+    "yarn": "1.22.19"
   },
   "browserslist": {
     "production": [

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,77 @@
+import { defineConfig, devices } from "@playwright/test"
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: "./tests/e2e",
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: "html",
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    // baseURL: 'http://127.0.0.1:3000',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: "on-first-retry"
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] }
+    },
+
+    {
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"] }
+    },
+
+    {
+      name: "webkit",
+      use: { ...devices["Desktop Safari"] }
+    }
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: "yarn dev",
+    url: "http://localhost:3000/",
+    reuseExistingServer: !process.env.CI
+  }
+})

--- a/tests/e2e/homepage.spec.ts
+++ b/tests/e2e/homepage.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect, type Page } from "@playwright/test"
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("http://localhost:3000")
+})
+
+test.describe("Maple Homepage", () => {
+  test("should display logo and text", async ({ page }) => {
+    const logo = page.getByAltText("logo").first()
+    expect(logo).toBeVisible()
+    expect(page.getByText("Let your voice be heard!")).toBeVisible()
+  })
+})

--- a/tests/e2e/homepage.spec.ts
+++ b/tests/e2e/homepage.spec.ts
@@ -7,7 +7,7 @@ test.beforeEach(async ({ page }) => {
 test.describe("Maple Homepage", () => {
   test("should display logo and text", async ({ page }) => {
     const logo = page.getByAltText("logo").first()
-    expect(logo).toBeVisible()
-    expect(page.getByText("Let your voice be heard!")).toBeVisible()
+    await expect(logo).toBeVisible()
+    await expect(page.getByText("Let your voice be heard!")).toBeVisible()
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2766,6 +2766,13 @@
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
+"@playwright/test@^1.43.1":
+  version "1.43.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.43.1.tgz#16728a59eb8ce0f60472f98d8886d6cab0fa3e42"
+  integrity sha512-HgtQzFgNEEo4TE22K/X7sYTYNqEMMTZmFS8kTq6m8hXj+m1D8TgwgIbumHddJa9h4yl4GkKb8/bgAl2+g7eDgA==
+  dependencies:
+    playwright "1.43.1"
+
 "@pmmmwh/react-refresh-webpack-plugin@^0.5.11":
   version "0.5.11"
   resolved "https://registry.yarnpkg.com/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.11.tgz#7c2268cedaa0644d677e8c4f377bc8fb304f714a"
@@ -8940,6 +8947,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
+fsevents@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
 fsevents@^2.3.2, fsevents@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
@@ -13444,6 +13456,20 @@ pkg-dir@^7.0.0:
   dependencies:
     find-up "^6.3.0"
 
+playwright-core@1.43.1:
+  version "1.43.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.43.1.tgz#0eafef9994c69c02a1a3825a4343e56c99c03b02"
+  integrity sha512-EI36Mto2Vrx6VF7rm708qSnesVQKbxEWvPrfA1IPY6HgczBplDx7ENtx+K2n4kJ41sLLkuGfmb0ZLSSXlDhqPg==
+
+playwright@1.43.1:
+  version "1.43.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.43.1.tgz#8ad08984ac66c9ef3d0db035be54dd7ec9f1c7d9"
+  integrity sha512-V7SoH0ai2kNt1Md9E3Gwas5B9m8KR2GVvwZnAI6Pg0m3sh7UvgiYhRrhsziCmqMJNouPckiOhk8T+9bSAK0VIA==
+  dependencies:
+    playwright-core "1.43.1"
+  optionalDependencies:
+    fsevents "2.3.2"
+
 please-upgrade-node@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz#aeddd3f994c933e4ad98b99d9a556efa0e2fe942"
@@ -15535,7 +15561,6 @@ string-width@^2.1.0:
     strip-ansi "^4.0.0"
 
 string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
-  name string-width-cjs
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -15620,7 +15645,6 @@ strip-ansi@^5.1.0:
     ansi-regex "^4.1.0"
 
 strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  name strip-ansi-cjs
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -17110,7 +17134,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
     strip-ansi "^6.0.0"
 
 wrap-ansi@^7.0.0:
-  name wrap-ansi-cjs
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==


### PR DESCRIPTION
# Summary

Issue: https://github.com/codeforboston/maple/issues/1508

This PR adds Playwright for e2e testing, a simple test for the MAPLE homepage. A redo of https://github.com/codeforboston/maple/pull/1535

I realized the initial issues I ran into that led me to updating package versions was likely due to using the wrong version of yarn. I started over, set my yarn version to v1.22.19 (same as the CI build), and reinstalled playwright without the extra changes. This is a much simpler PR now!

## How to run tests

There are two ways you can run the e2e tests, with the Playwright UI or headless in your terminal. This will automatically start the application so you don't need to do it before running tests.

### With Playwright UI
To run the e2e tests with the Playwright UI, run `yarn test:e2e`. Once the UI pops up and the tests have loaded, press the play button in the "TESTS" bar to run all the tests. To run individual tests or test suites, you can hover over the test name to reveal a play button that will run only that test/suite when clicked.
![image](https://github.com/codeforboston/maple/assets/16471076/5d3f486d-28f7-4d4f-8fd7-e35dfa19cbca)


### Headless
To run the e2e tests headless in your terminal, run `yarn test:e2e:headless`. The results of this test run will show on your terminal, and it will also generate an HTML report that will open in your browser.
![image](https://github.com/codeforboston/maple/assets/16471076/13b8fd5c-5f6d-4b24-bbae-3fe95669a951)

![image](https://github.com/codeforboston/maple/assets/16471076/75ef8000-5a51-480b-90fd-c0b017bf4f9e)


# Screenshots

Note: My macbook is old and I can't update it anymore. The screenshot shows the webkit test is failing, but it's because the version I have is incompatible 😓 
![image](https://github.com/codeforboston/maple/assets/16471076/b8a8396e-be2d-410d-a1a7-7e8dbf2b6a0b)
