### PR TITLE
Add i18n linting

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,6 @@
 {
   "extends": ["next", "next/core-web-vitals", "prettier"],
+  "plugins": ["i18next"],
   "rules": {
     // TODO: Fix these warnings and make them errors by removing these overrides.
     "react/no-unescaped-entities": "off",
@@ -10,6 +11,8 @@
       {
         "additionalHooks": "^useAsync$"
       }
-    ]
+    ],
+    // TODO: Fix existing warnings and make them errors going forward
+    "i18next/no-literal-string": "warn"
   }
 }

--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "eslint": "^8.7.0",
     "eslint-config-next": "^14.0.4",
     "eslint-config-prettier": "^8.3.0",
+    "eslint-plugin-i18next": "^6.0.3",
     "firebase-admin": "^10",
     "firebase-tools": "^11.16.0",
     "ini": "^1.3.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8008,6 +8008,14 @@ eslint-module-utils@^2.7.4, eslint-module-utils@^2.8.0:
   dependencies:
     debug "^3.2.7"
 
+eslint-plugin-i18next@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-i18next/-/eslint-plugin-i18next-6.0.3.tgz#a388f9982deb040102c1c4498e4dc38d9bd6ffd9"
+  integrity sha512-RtQXYfg6PZCjejIQ/YG+dUj/x15jPhufJ9hUDGH0kCpJ6CkVMAWOQ9exU1CrbPmzeykxLjrXkjAaOZF/V7+DOA==
+  dependencies:
+    lodash "^4.17.21"
+    requireindex "~1.1.0"
+
 eslint-plugin-import@^2.28.1:
   version "2.29.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.29.0.tgz#8133232e4329ee344f2f612885ac3073b0b7e155"
@@ -14734,6 +14742,11 @@ require-package-name@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/require-package-name/-/require-package-name-2.0.1.tgz#c11e97276b65b8e2923f75dabf5fb2ef0c3841b9"
   integrity sha512-uuoJ1hU/k6M0779t3VMVIYpb2VMJk05cehCaABFhXaibcbvfgR8wKiozLjVFSzJPmQMRqIcO0HMyTFqfV09V6Q==
+
+requireindex@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.1.0.tgz#e5404b81557ef75db6e49c5a72004893fe03e162"
+  integrity sha512-LBnkqsDE7BZKvqylbmn7lTIVdpx4K/QCduRATpO5R+wtPmky/a8pN1bO2D6wXppn1497AJF9mNjqAXr6bdl9jg==
 
 requires-port@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
# Summary

We want to be able to identify unextracted user-visible text for I18n translation - both to help with clearing out the backlog of existing text to extract and to ensure we maintain the standard going forward.

To that end, this PR enables an eslint rule to warn about unextracted literal strings. The game plan is to enable this at a non-blocking warn level while we clear out the backlog, and then flip this to an actual build error once the codebase is fully compliant to ensure it stays that way.

# Checklist

- [na] On the frontend, I've made my strings translate-able.
- [na] If I've added shared components, I've added a storybook story.
- [na] I've made pages responsive and look good on mobile.

# Screenshots

This will produce warnings that look like: 

```
./components/bill/TestimonyCounts.tsx
63:45  Error: disallow literal string: <CountTotal className={`ms-2`}>{total} Total Testimonies</CountTotal>  i18next/no-literal-string
66:26  Error: disallow literal string: <CountCategory>Endorse</CountCategory>  i18next/no-literal-string
75:26  Error: disallow literal string: <CountCategory>Neutral</CountCategory>  i18next/no-literal-string
84:26  Error: disallow literal string: <CountCategory>Oppose</CountCategory>  i18next/no-literal-string


./components/buttons.tsx
337:39  Error: disallow literal string: <Tooltip {...props}>Copied to Clipboard!</Tooltip>  i18next/no-literal-string
```
# Known issues

N/A

# Steps to test/reproduce

N/A