### PR TITLE
Refactor footer #1561

### DIFF
--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -30,15 +30,14 @@ const TextHeader = styled.h6`
 `
 const BrowseHeader = styled(NavLink)`
   font-size: 1rem;
-  font-weight: bold;
   color: #fff;
   font-family: Nunito;
   padding: 0.5rem 1rem 0 0;
   margin: 0 0 10px 0;
 
   @media (max-width: 768px) {
-    padding-bottom: 0.5rem;
-    border-bottom: solid 1px rgba(255, 255, 255, 0.75);
+    padding-bottom: 0.6rem;
+    border-bottom: solid 1.5px rgba(255, 255, 255, 0.75);
     margin: 0;
   }
 `

--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -5,12 +5,13 @@ import { useAppDispatch } from "components/hooks"
 import { User } from "firebase/auth"
 import { useTranslation } from "next-i18next"
 import styled from "styled-components"
-import { ExternalNavLink, NavLink } from "../Navlink"
+import { NavLink } from "../Navlink"
 import { Button, Col, Image, Container, Row, Nav, Navbar } from "../bootstrap"
 import CustomDropdown, {
   CustomDropdownProps
 } from "components/Footer/CustomFooterDropdown"
 import { FooterContainer } from "./FooterContainer"
+import { useMediaQuery } from "usehooks-ts"
 
 export type PageFooterProps = {
   children?: any
@@ -27,23 +28,27 @@ const TextHeader = styled.h6`
   padding: 0.5rem 1rem 0 0;
   margin: 0;
 `
+const BrowseHeader = styled(NavLink)`
+  font-size: 1rem;
+  font-weight: bold;
+  color: #fff;
+  font-family: Nunito;
+  padding: 0.5rem 1rem 0 0;
+  margin: 0 0 10px 0;
+
+  @media (max-width: 768px) {
+    padding-bottom: 0.5rem;
+    border-bottom: solid 1px rgba(255, 255, 255, 0.75);
+    margin: 0;
+  }
+`
 
 const StyledInternalLink = styled(NavLink)`
   color: rgba(255, 255, 255, 0.55);
   font-family: Nunito;
   letter-spacing: -0.63px;
   padding-top: 4;
-
-  &:hover {
-    color: white;
-    text-decoration: none;
-  }
-`
-const StyledExternalLink = styled(ExternalNavLink)`
-  color: rgba(255, 255, 255, 0.55);
-  font-family: Nunito;
-  letter-spacing: -0.63px;
-  padding-top: 4;
+  margin: 5px 0;
 
   &:hover {
     color: white;
@@ -201,12 +206,10 @@ const BrowseList = () => {
   const { t } = useTranslation("common")
   return (
     <>
-      <StyledInternalLink href="/testimony">
+      <BrowseHeader href="/testimony">
         {t("navigation.browseTestimony")}
-      </StyledInternalLink>
-      <StyledInternalLink href="/bills">
-        {t("navigation.browseBills")}
-      </StyledInternalLink>
+      </BrowseHeader>
+      <BrowseHeader href="/bills">{t("navigation.browseBills")}</BrowseHeader>
     </>
   )
 }

--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -62,20 +62,6 @@ function MapleContainer({ className }: { className?: string }) {
         <Col style={{ display: "flex", justifyContent: "center" }}>
           <Button
             variant="light"
-            href="https://www.instagram.com/mapletestimony/?hl=en"
-            style={{ borderRadius: 50, padding: 8, margin: 5 }}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              src="/images/instagram.svg"
-              alt="Instagram Icon"
-              width="24"
-              height="24"
-            ></Image>
-          </Button>
-          <Button
-            variant="light"
             style={{ borderRadius: 50, padding: 8, margin: 5 }}
             href="https://twitter.com/MapleTestimony"
             target="_blank"
@@ -84,6 +70,20 @@ function MapleContainer({ className }: { className?: string }) {
             <Image
               src="/images/twitter.svg"
               alt="Twitter Icon"
+              width="24"
+              height="24"
+            ></Image>
+          </Button>
+          <Button
+            variant="light"
+            href="https://www.instagram.com/mapletestimony/?hl=en"
+            style={{ borderRadius: 50, padding: 8, margin: 5 }}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <Image
+              src="/images/instagram.svg"
+              alt="Instagram Icon"
               width="24"
               height="24"
             ></Image>
@@ -116,47 +116,19 @@ function MapleContainer({ className }: { className?: string }) {
   )
 }
 
-const ResourcesLinks = () => {
+const TermsAndPolicies = () => {
   const { t } = useTranslation("footer")
   return (
     <>
-      <StyledExternalLink href="https://malegislature.gov/Search/FindMyLegislator">
-        {t("links.resourcesLegislators")}
-      </StyledExternalLink>
-      <StyledExternalLink href="https://github.com/codeforboston/maple">
-        {t("links.resourcesGitHub")}
-      </StyledExternalLink>
-      <StyledExternalLink href="https://opencollective.com/mapletestimony">
-        {t("links.resourcesOpenCollective")}
-      </StyledExternalLink>
-    </>
-  )
-}
-
-const BrowseLinks = () => {
-  const { t } = useTranslation("common")
-  return (
-    <>
-      <StyledInternalLink href="/bills">
-        {t("navigation.browseBills")}
+      <StyledInternalLink href="/policies">
+        {t("Privacy Policy")}
       </StyledInternalLink>
-      <StyledInternalLink href="/testimony">
-        {t("navigation.browseTestimony")}
+      <StyledInternalLink href="/policies/copyright">
+        {t("Terms of Service")}
       </StyledInternalLink>
-    </>
-  )
-}
-
-const OurTeamLinks = () => {
-  const { t } = useTranslation("footer")
-  return (
-    <>
-      <StyledExternalLink href="https://www.nulawlab.org">
-        {t("links.teamNEU")}
-      </StyledExternalLink>
-      <StyledExternalLink href="https://www.codeforboston.org/">
-        {t("links.teamCFB")}
-      </StyledExternalLink>
+      <StyledInternalLink href="/policies/code-of-conduct">
+        {t("Code of Conduct")}
+      </StyledInternalLink>
     </>
   )
 }
@@ -193,13 +165,13 @@ const LearnLinks = () => {
   return (
     <>
       <StyledInternalLink href="/learn/writing-effective-testimony">
-        {t("links.learnWriting")}
+        {t("To Writing Effective Testimony")}
       </StyledInternalLink>
-      <StyledInternalLink href="/learn/communicating-with-legislators">
-        {t("links.learnLegislators")}
+      <StyledInternalLink href="/learn/legislative-process">
+        {t("About the Legislative Process", { ns: "common" })}
       </StyledInternalLink>
-      <StyledInternalLink href="/learn/additional-resources">
-        {t("navigation.additionalResources", { ns: "common" })}
+      <StyledInternalLink href="/why-use-maple/for-individuals">
+        {t("Why use MAPLE")}
       </StyledInternalLink>
     </>
   )
@@ -210,10 +182,38 @@ const AboutLinks = () => {
   return (
     <>
       <StyledInternalLink href="/about/mission-and-goals">
-        {t("navigation.missionAndGoals")}
+        {t("Mission & Goals")}
       </StyledInternalLink>
       <StyledInternalLink href="/about/our-team">
-        {t("team")}
+        {t("Team")}
+      </StyledInternalLink>
+      <StyledInternalLink href="/about/support-maple">
+        {t("Support MAPLE")}
+      </StyledInternalLink>
+      <StyledInternalLink href="/about/faq-page">
+        {t("navigation.faq")}
+      </StyledInternalLink>
+    </>
+  )
+}
+
+const BrowseTestimony = () => {
+  const { t } = useTranslation("common")
+  return (
+    <>
+      <StyledInternalLink href="/testimony">
+        {t("navigation.browseTestimony")}
+      </StyledInternalLink>
+    </>
+  )
+}
+
+const BrowseBills = () => {
+  const { t } = useTranslation("common")
+  return (
+    <>
+      <StyledInternalLink href="/bills">
+        {t("navigation.browseBills")}
       </StyledInternalLink>
     </>
   )
@@ -232,9 +232,10 @@ const PageFooter = (props: PageFooterProps) => {
         className="d-md-none w-100 order-1 p-2 mb-2"
       >
         <Nav className={`d-flex w-100`}>
-          <CustomDropdown title={t("headers.browse")}>
-            <BrowseLinks />
-          </CustomDropdown>
+          <BrowseTestimony />
+
+          <BrowseBills />
+
           <CustomDropdown title={t("headers.account")}>
             <AccountLinks {...props} />
           </CustomDropdown>
@@ -248,33 +249,27 @@ const PageFooter = (props: PageFooterProps) => {
           </CustomDropdown>
 
           <CustomDropdown title={t("headers.resources")}>
-            <ResourcesLinks />
-          </CustomDropdown>
-
-          <CustomDropdown title={t("team", { ns: "common" })}>
-            <OurTeamLinks />
+            <TermsAndPolicies />
           </CustomDropdown>
         </Nav>
       </Navbar>
       <div className={`d-none d-md-flex order-1 flex-grow-1`}>
         <Col>
-          <TextHeader>{t("headers.browse")}</TextHeader>
-          <BrowseLinks />
+          <BrowseTestimony />
+          <BrowseBills />
           <TextHeader>{t("headers.account")}</TextHeader>
 
           <AccountLinks {...props} />
         </Col>
         <Col>
-          <TextHeader>{t("learn", { ns: "common" })}</TextHeader>
-          <LearnLinks />
           <TextHeader>{t("about", { ns: "common" })}</TextHeader>
           <AboutLinks />
+          <TextHeader>{t("learn", { ns: "common" })}</TextHeader>
+          <LearnLinks />
         </Col>
         <Col>
           <TextHeader>{t("headers.resources")}</TextHeader>
-          <ResourcesLinks />
-          <TextHeader>{t("team", { ns: "common" })}</TextHeader>
-          <OurTeamLinks />
+          <TermsAndPolicies />
         </Col>
       </div>
       <MapleContainer className={`col-auto order-md-2 justify-self-end `} />
@@ -282,22 +277,6 @@ const PageFooter = (props: PageFooterProps) => {
         className={`d-flex flex-column gap-2 flex-md-row flex-wrap col-12 flex-shrink-0 order-md-3 text-center text-md-start`}
       >
         <Col className="text-white col-md-auto">{t("legal.disclaimer")}</Col>
-        <Col className="text-center">
-          <StyledInternalLink href="/policies">
-            {t("legal.TOS")}
-          </StyledInternalLink>
-        </Col>
-        <Col className="">
-          <StyledInternalLink
-            href="https://cdn.forms-content.sg-form.com/fc8a7d49-d903-11ed-9e53-c2519c5b83a4"
-            other={{
-              target: "_blank",
-              rel: "noopener noreferrer"
-            }}
-          >
-            {t("Click here to subscribe to our newsletter")}
-          </StyledInternalLink>
-        </Col>
       </div>
     </FooterContainer>
   )

--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -39,6 +39,10 @@ const BrowseHeader = styled(NavLink)`
     border-bottom: solid 1.5px rgba(255, 255, 255, 0.75);
     margin: 0;
   }
+
+  &:hover {
+    color: white;
+  }
 `
 
 const StyledInternalLink = styled(NavLink)`

--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -42,6 +42,7 @@ const BrowseHeader = styled(NavLink)`
 
   &:hover {
     color: white;
+    text-decoration: underline 1.5px;
   }
 `
 

--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -124,13 +124,13 @@ const TermsAndPolicies = () => {
   return (
     <>
       <StyledInternalLink href="/policies">
-        {t("Privacy Policy")}
+        {t("legal.privacyPolicy")}
       </StyledInternalLink>
       <StyledInternalLink href="/policies/copyright">
-        {t("Terms of Service")}
+        {t("legal.TOS")}
       </StyledInternalLink>
       <StyledInternalLink href="/policies/code-of-conduct">
-        {t("Code of Conduct")}
+        {t("legal.codeOfConduct")}
       </StyledInternalLink>
     </>
   )
@@ -168,33 +168,33 @@ const LearnLinks = () => {
   return (
     <>
       <StyledInternalLink href="/learn/writing-effective-testimony">
-        {t("To Writing Effective Testimony")}
+        {t("links.learnWriting")}
       </StyledInternalLink>
       <StyledInternalLink href="/learn/legislative-process">
-        {t("About the Legislative Process", { ns: "common" })}
+        {t("links.learnProcess")}
       </StyledInternalLink>
       <StyledInternalLink href="/why-use-maple/for-individuals">
-        {t("Why use MAPLE")}
+        {t("links.learnWhy")}
       </StyledInternalLink>
     </>
   )
 }
 
 const AboutLinks = () => {
-  const { t } = useTranslation("common")
+  const { t } = useTranslation(["footer", "common"])
   return (
     <>
       <StyledInternalLink href="/about/mission-and-goals">
-        {t("Mission & Goals")}
+        {t("links.ourMission")}
       </StyledInternalLink>
       <StyledInternalLink href="/about/our-team">
-        {t("Team")}
+        {t("links.team")}
       </StyledInternalLink>
       <StyledInternalLink href="/about/support-maple">
-        {t("Support MAPLE")}
+        {t("links.supportMaple")}
       </StyledInternalLink>
       <StyledInternalLink href="/about/faq-page">
-        {t("navigation.faq")}
+        {t("links.faq")}
       </StyledInternalLink>
     </>
   )

--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -11,7 +11,6 @@ import CustomDropdown, {
   CustomDropdownProps
 } from "components/Footer/CustomFooterDropdown"
 import { FooterContainer } from "./FooterContainer"
-import { useMediaQuery } from "usehooks-ts"
 
 export type PageFooterProps = {
   children?: any

--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -197,21 +197,13 @@ const AboutLinks = () => {
   )
 }
 
-const BrowseTestimony = () => {
+const BrowseList = () => {
   const { t } = useTranslation("common")
   return (
     <>
       <StyledInternalLink href="/testimony">
         {t("navigation.browseTestimony")}
       </StyledInternalLink>
-    </>
-  )
-}
-
-const BrowseBills = () => {
-  const { t } = useTranslation("common")
-  return (
-    <>
       <StyledInternalLink href="/bills">
         {t("navigation.browseBills")}
       </StyledInternalLink>
@@ -232,9 +224,7 @@ const PageFooter = (props: PageFooterProps) => {
         className="d-md-none w-100 order-1 p-2 mb-2"
       >
         <Nav className={`d-flex w-100`}>
-          <BrowseTestimony />
-
-          <BrowseBills />
+          <BrowseList />
 
           <CustomDropdown title={t("headers.account")}>
             <AccountLinks {...props} />
@@ -255,8 +245,7 @@ const PageFooter = (props: PageFooterProps) => {
       </Navbar>
       <div className={`d-none d-md-flex order-1 flex-grow-1`}>
         <Col>
-          <BrowseTestimony />
-          <BrowseBills />
+          <BrowseList />
           <TextHeader>{t("headers.account")}</TextHeader>
 
           <AccountLinks {...props} />

--- a/public/locales/en/footer.json
+++ b/public/locales/en/footer.json
@@ -6,17 +6,18 @@
     "resources": "Resources"
   },
   "links": {
-    "learnWriting": "Writing Effective Testimony",
-    "learnLegislators": "Contacting Legislators",
-    "resourcesLegislators": "Find your Legislators",
-    "resourcesGitHub": "MAPLE on GitHub",
-    "resourcesOpenCollective": "MAPLE OpenCollective",
-    "teamNEU": "Northeastern University NuLawLab",
-    "teamCFB": "Code for Boston",
-    "teamHarvard": "Harvard Berkman Klein Center"
+    "learnWriting": "To Writing Effective Testimony",
+    "learnProcess": "About the Legislative Process",
+    "learnWhy": "Why use MAPLE",
+    "supportMaple": "Support MAPLE",
+    "ourMission": "Mission & Goals",
+    "team": "Team",
+    "faq": "FAQ"
   },
   "legal": {
     "disclaimer": "MAPLE is an independent project, not affiliated with the Massachusetts legislature",
-    "TOS": "Our Privacy Policy & Terms of Service"
+    "privacyPolicy": "Privacy Policy",
+    "TOS": "Terms of Service",
+    "codeOfConduct": "Code of Conduct"
   }
 }


### PR DESCRIPTION
# Summary

- Reorganized footer links
- Removed external link styled component
- Created new styled component for non-navbar drop items to match styling

# Checklist

- [ ] On the frontend, I've made my strings translate-able.
- [ ] If I've added shared components, I've added a storybook story.
- [ ] I've made pages responsive and look good on mobile.

# Screenshots

![image_2024-06-18_194543716](https://github.com/codeforboston/maple/assets/94672626/01673059-9745-4010-812a-eca3e9368f04)
![refactor-footer1](https://github.com/codeforboston/maple/assets/94672626/0ae821f2-8447-4ff9-9457-d54f73fb1b51)


# Known issues

Only caveat is the spacing of the footer on desktop. Might need to redo footer in columns and rows to create even spaces between bottom and top half of footer

# Steps to test/reproduce

_For each feature or bug fix, create a step by step list for how a reviewer can test it out. E.g.:_

1. Go to the home page
2. Go to footer
