### PR TITLE
Fixing bug in Hearings Scheduled component

### DIFF
--- a/components/HearingsScheduled/HearingsScheduled.tsx
+++ b/components/HearingsScheduled/HearingsScheduled.tsx
@@ -90,7 +90,8 @@ export const EventCard = ({
   const truncateEntry = (entry: string): string => {
     const maxLength = 38
 
-    if (entry.length > maxLength) return entry.slice(0, maxLength) + "..."
+    if (!!entry && entry.length > maxLength)
+      return entry.slice(0, maxLength) + "..."
     return entry
   }
 


### PR DESCRIPTION
Previously, a missing location would cause the truncateEntry function to throw an error when we tried to truncate null. Now, we only attempt to truncate if there actually is an entry to truncate (and simply display nothing if there is no location). Huge thanks to Kimin for tracking this down!

# Screenshots

<img width="1119" alt="Screenshot 2024-07-11 at 3 11 29 PM" src="https://github.com/codeforboston/maple/assets/2694761/9fb4be1d-2fa8-491d-8e3a-fcfaeb0d62ac">

# Known issues

N/A

# Steps to test/reproduce

1. Go to the home page
1. It loads now - hooray!