### PR TITLE
[1584] Migrate to React InstantSearch v7

### DIFF
--- a/components/search/ResultCount.tsx
+++ b/components/search/ResultCount.tsx
@@ -1,10 +1,5 @@
-import { useConnector } from "@alexjball/react-instantsearch-hooks-web"
-import connectStats from "instantsearch.js/es/connectors/stats/connectStats"
+import { useStats } from "react-instantsearch"
 import styled from "styled-components"
-
-function useStats(): any {
-  return useConnector(connectStats)
-}
 
 const ResultContainer = styled.span`
   font-size: 0.75rem;
@@ -12,8 +7,9 @@ const ResultContainer = styled.span`
 export function ResultCount(props: any) {
   const { hitsPerPage, nbHits, page } = useStats()
 
-  const pageStart = Math.min(page * hitsPerPage + 1, nbHits)
-  const pageEnd = Math.min(pageStart + hitsPerPage - 1, nbHits)
+  const limit = hitsPerPage || 0
+  const pageStart = Math.min(page * limit + 1, nbHits)
+  const pageEnd = Math.min(pageStart + limit - 1, nbHits)
 
   return (
     <ResultContainer {...props}>

--- a/components/search/SortBy.tsx
+++ b/components/search/SortBy.tsx
@@ -1,8 +1,4 @@
-import {
-  useSortBy,
-  useConfigure,
-  UseConfigureProps
-} from "@alexjball/react-instantsearch-hooks-web"
+import { useSortBy, useConfigure, UseConfigureProps } from "react-instantsearch"
 import { SortByItem } from "instantsearch.js/es/connectors/sort-by/connectSortBy"
 import Select from "react-select"
 import styled from "styled-components"

--- a/components/search/bills/BillHit.tsx
+++ b/components/search/bills/BillHit.tsx
@@ -1,4 +1,4 @@
-import { Highlight } from "@alexjball/react-instantsearch-hooks-web"
+import { Highlight } from "react-instantsearch"
 import {
   faCheckCircle,
   faMinusCircle,

--- a/components/search/bills/BillSearch.tsx
+++ b/components/search/bills/BillSearch.tsx
@@ -4,11 +4,9 @@ import {
   InstantSearch,
   Pagination,
   SearchBox,
-  useConfigure,
   useInstantSearch
-} from "@alexjball/react-instantsearch-hooks-web"
+} from "react-instantsearch"
 import { currentGeneralCourt } from "functions/src/shared"
-import { SortByItem } from "instantsearch.js/es/connectors/sort-by/connectSortBy"
 import styled from "styled-components"
 import TypesenseInstantSearchAdapter from "typesense-instantsearch-adapter"
 import { Col, Row } from "../../bootstrap"
@@ -78,6 +76,7 @@ const Layout: FC<
 > = ({ items }) => {
   const refinements = useBillRefinements()
   const status = useSearchStatus()
+
   return (
     <SearchContainer>
       <Row>

--- a/components/search/bills/useBillRefinements.tsx
+++ b/components/search/bills/useBillRefinements.tsx
@@ -1,4 +1,3 @@
-import { useRefinementListUiProps } from "@alexjball/react-instantsearch-hooks-web"
 import { generalCourts } from "functions/src/shared"
 import { RefinementListItem } from "instantsearch.js/es/connectors/refinement-list/connectRefinementList"
 import { useCallback } from "react"
@@ -7,7 +6,7 @@ import { useRefinements } from "../useRefinements"
 export const useBillRefinements = () => {
   const baseProps = { limit: 500, searchable: true }
   const propsList = [
-    useRefinementListUiProps({
+    {
       transformItems: useCallback(
         (i: RefinementListItem[]) =>
           i
@@ -21,27 +20,27 @@ export const useBillRefinements = () => {
       attribute: "court",
       searchablePlaceholder: "General Court",
       ...baseProps
-    }),
-    useRefinementListUiProps({
+    },
+    {
       attribute: "currentCommittee",
       ...baseProps,
       searchablePlaceholder: "Current Committee"
-    }),
-    useRefinementListUiProps({
+    },
+    {
       attribute: "city",
       searchablePlaceholder: "City",
       ...baseProps
-    }),
-    useRefinementListUiProps({
+    },
+    {
       attribute: "primarySponsor",
       ...baseProps,
       searchablePlaceholder: "Primary Sponsor"
-    }),
-    useRefinementListUiProps({
+    },
+    {
       attribute: "cosponsors",
       ...baseProps,
       searchablePlaceholder: "Cosponsor"
-    })
+    }
   ]
 
   return useRefinements({ refinementProps: propsList })

--- a/components/search/testimony/TestimonySearch.tsx
+++ b/components/search/testimony/TestimonySearch.tsx
@@ -5,7 +5,7 @@ import {
   Pagination,
   SearchBox,
   useInstantSearch
-} from "@alexjball/react-instantsearch-hooks-web"
+} from "react-instantsearch"
 import {
   StyledTabContent,
   StyledTabNav

--- a/components/search/testimony/useTestimonyRefinements.tsx
+++ b/components/search/testimony/useTestimonyRefinements.tsx
@@ -1,12 +1,11 @@
-import { useRefinementListUiProps } from "@alexjball/react-instantsearch-hooks-web"
+import { RefinementListItem } from "instantsearch.js/es/connectors/refinement-list/connectRefinementList"
 import { useRefinements } from "../useRefinements"
 import { useCallback } from "react"
-import { RefinementListItem } from "instantsearch.js/es/connectors/refinement-list/connectRefinementList"
 
 export const useTestimonyRefinements = () => {
   const baseProps = { limit: 500, searchable: true }
   const propsList = [
-    useRefinementListUiProps({
+    {
       transformItems: useCallback(
         (i: RefinementListItem[]) => i.filter(i => i.label !== "private"),
         []
@@ -14,28 +13,28 @@ export const useTestimonyRefinements = () => {
       attribute: "authorDisplayName",
       ...baseProps,
       searchablePlaceholder: "Author Name"
-    }),
-    useRefinementListUiProps({
+    },
+    {
       attribute: "court",
       ...baseProps,
       searchablePlaceholder: "Court"
-    }),
-    useRefinementListUiProps({
+    },
+    {
       attribute: "position",
       ...baseProps,
       searchablePlaceholder: "Position"
-    }),
-    useRefinementListUiProps({
+    },
+    {
       attribute: "billId",
       ...baseProps,
       searchablePlaceholder: "Bill"
-    }),
-    useRefinementListUiProps({
+    },
+    {
       attribute: "authorRole",
       ...baseProps,
       searchable: false,
       hidden: true
-    })
+    }
   ]
 
   return useRefinements({ refinementProps: propsList })

--- a/components/search/useRefinements.tsx
+++ b/components/search/useRefinements.tsx
@@ -1,7 +1,4 @@
-import {
-  RefinementListUiComponent,
-  useInstantSearch
-} from "@alexjball/react-instantsearch-hooks-web"
+import { RefinementList, useInstantSearch } from "react-instantsearch"
 import { faFilter } from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { useCallback, useEffect, useState } from "react"
@@ -41,7 +38,7 @@ export const useRefinements = ({
   const refinements = (
     <>
       {refinementProps.map((p, i) => (
-        <RefinementListUiComponent className="mb-4" key={i} {...(p as any)} />
+        <RefinementList className="mb-4" key={i} {...(p as any)} />
       ))}
     </>
   )

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     ]
   },
   "dependencies": {
-    "@alexjball/react-instantsearch-hooks-web": "~6.29.1",
     "@emotion/weak-memoize": "^0.3.1",
     "@fortawesome/fontawesome-svg-core": "^6.5.1",
     "@fortawesome/free-solid-svg-icons": "^6.5.1",
@@ -116,6 +115,7 @@
     "react-hook-form": "^7.33.1",
     "react-i18next": "^13.2.2",
     "react-inlinesvg": "^3.0.1",
+    "react-instantsearch": "^7.12.4",
     "react-is": "^18.2.0",
     "react-markdown": "^8.0.4",
     "react-overlays": "^5.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,15 +12,6 @@
   resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.3.2.tgz#a6abc715fb6884851fca9dad37fc34739a04fd11"
   integrity sha512-DA5a1C0gD/pLOvhv33YMrbf2FK3oUzwNl9oOJqE4XVjuEtt6XIakRcsd7eLiOSPkp1kTRQGICTA8cKra/vFbjw==
 
-"@alexjball/react-instantsearch-hooks-web@~6.29.1":
-  version "6.29.1"
-  resolved "https://registry.yarnpkg.com/@alexjball/react-instantsearch-hooks-web/-/react-instantsearch-hooks-web-6.29.1.tgz#3768239d6d94e6b2170b26403c06fbfd69d36b7b"
-  integrity sha512-fKLP7VBCXVyS60boiSBKdkbnHnC/EiZRalBrbgAtqbufxbCNdMxknIr53fozy4CWfiRT2sJu33OwiCTDFYF84A==
-  dependencies:
-    "@babel/runtime" "^7.1.2"
-    instantsearch.js "^4.43.0"
-    react-instantsearch-hooks "6.29.0"
-
 "@algolia/events@^4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@algolia/events/-/events-4.0.1.tgz#fd39e7477e7bc703d7f893b556f676c032af3950"
@@ -1172,10 +1163,17 @@
   resolved "https://registry.yarnpkg.com/@babel/regjsgen/-/regjsgen-0.8.0.tgz#f0ba69b075e1f05fb2825b7fad991e7adbb18310"
   integrity sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.13.8", "@babel/runtime@^7.17.8", "@babel/runtime@^7.18.3", "@babel/runtime@^7.18.9", "@babel/runtime@^7.20.13", "@babel/runtime@^7.22.5", "@babel/runtime@^7.23.2", "@babel/runtime@^7.23.4", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.13.8", "@babel/runtime@^7.17.8", "@babel/runtime@^7.18.3", "@babel/runtime@^7.18.9", "@babel/runtime@^7.20.13", "@babel/runtime@^7.22.5", "@babel/runtime@^7.23.2", "@babel/runtime@^7.23.4", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.23.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.5.tgz#11edb98f8aeec529b82b211028177679144242db"
   integrity sha512-NdUTHcPe4C99WxPub+K9l9tK5/lV4UXIoaHSYgzco9BCyjKAAwzdBI+wWtYqHt7LJdbo74ZjRPJgzVweq1sz0w==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
+"@babel/runtime@^7.1.2":
+  version "7.25.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.25.0.tgz#3af9a91c1b739c569d5d80cc917280919c544ecb"
+  integrity sha512-7dRy4DwXwtzBrPbZflqxnvfxLF8kdZXPkhymtDeFoFqE6ldzjQFgYTtYIFARcLEYDrqfBfYcZt1WqFxRoyC9Rw==
   dependencies:
     regenerator-runtime "^0.14.0"
 
@@ -5235,10 +5233,17 @@ ajv@^8.0.0, ajv@^8.3.0, ajv@^8.9.0:
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
-algoliasearch-helper@3.16.0, algoliasearch-helper@^3.9.0:
+algoliasearch-helper@3.16.0:
   version "3.16.0"
   resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-3.16.0.tgz#42c7c8cecf5fa91fb9dd467011fa68c9050be7dc"
   integrity sha512-RxOtBafSQwyqD5BLO/q9VsVw/zuNz8kjb51OZhCIWLr33uvKB+vrRis+QK+JFlNQXbXf+w28fsTWiBupc1pHew==
+  dependencies:
+    "@algolia/events" "^4.0.1"
+
+algoliasearch-helper@3.22.3:
+  version "3.22.3"
+  resolved "https://registry.yarnpkg.com/algoliasearch-helper/-/algoliasearch-helper-3.22.3.tgz#7c67a1a87c3adb0b52ef726a3de3c0b0edcbb5d1"
+  integrity sha512-2eoEz8mG4KHE+DzfrBTrCmDPxVXv7aZZWPojAJFtARpxxMO6lkos1dJ+XDCXdPvq7q3tpYWRi6xXmVQikejtpA==
   dependencies:
     "@algolia/events" "^4.0.1"
 
@@ -10021,12 +10026,37 @@ install-artifact-from-github@^1.3.5:
   resolved "https://registry.yarnpkg.com/install-artifact-from-github/-/install-artifact-from-github-1.3.5.tgz#88c96fe40e5eb21d45586d564208c648a1dbf38d"
   integrity sha512-gZHC7f/cJgXz7MXlHFBxPVMsvIbev1OQN1uKQYKVJDydGNm9oYf9JstbU4Atnh/eSvk41WtEovoRm+8IF686xg==
 
+instantsearch-ui-components@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/instantsearch-ui-components/-/instantsearch-ui-components-0.8.0.tgz#2ba660c449cc882bd4ec09fa3deefe94e638de7b"
+  integrity sha512-EzV7cR5+18sjmR6DMdv8yL9WuS2hUxrkqbByiLmHnJFbB4TZ4Q7oZDAn43bOItWZ2TxMK3GoxNbB/ZhWjsptPg==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+
 instantsearch.css@^7.4.5:
   version "7.4.5"
   resolved "https://registry.yarnpkg.com/instantsearch.css/-/instantsearch.css-7.4.5.tgz#2a521aa634329bf1680f79adf87c79d67669ec8d"
   integrity sha512-iIGBYjCokU93DDB8kbeztKtlu4qVEyTg1xvS6iSO1YvqRwkIZgf0tmsl/GytsLdZhuw8j4wEaeYsCzNbeJ/zEQ==
 
-instantsearch.js@^4.42.0, instantsearch.js@^4.43.0:
+instantsearch.js@4.73.4:
+  version "4.73.4"
+  resolved "https://registry.yarnpkg.com/instantsearch.js/-/instantsearch.js-4.73.4.tgz#5d6606ccf410bee808fbb2c1e915efbb74c5b658"
+  integrity sha512-QdvExJthRBXpRaX9lzey+2sqUIzlOZEpd8N5wZyLYYs6WjDHIwrNPOzmOv7VHLBBHGqZ6YkXoCoegj5zm9QI8g==
+  dependencies:
+    "@algolia/events" "^4.0.1"
+    "@types/dom-speech-recognition" "^0.0.1"
+    "@types/google.maps" "^3.45.3"
+    "@types/hogan.js" "^3.0.0"
+    "@types/qs" "^6.5.3"
+    algoliasearch-helper "3.22.3"
+    hogan.js "^3.0.2"
+    htm "^3.0.0"
+    instantsearch-ui-components "0.8.0"
+    preact "^10.10.0"
+    qs "^6.5.1 < 6.10"
+    search-insights "^2.15.0"
+
+instantsearch.js@^4.43.0:
   version "4.62.0"
   resolved "https://registry.yarnpkg.com/instantsearch.js/-/instantsearch.js-4.62.0.tgz#68577f4f04866728f22441cbc7464c544678d342"
   integrity sha512-zq8kQpLR8xuWH59UtkJmr0iJs/M0VlvBVeMzVmpwkbfUNPpAcYPSjxw0iBR4QgqeyOUqWnZfhLJHUVmD+H+lLg==
@@ -14283,15 +14313,25 @@ react-inlinesvg@^3.0.1:
     exenv "^1.2.2"
     react-from-dom "^0.6.2"
 
-react-instantsearch-hooks@6.29.0:
-  version "6.29.0"
-  resolved "https://registry.yarnpkg.com/react-instantsearch-hooks/-/react-instantsearch-hooks-6.29.0.tgz#74eba7a06f69465031b50d9da10a57db545cb914"
-  integrity sha512-F4kLBkhELffrT7vaYW5gpja2R6b3v7rreDpod9nQmyyRW0ww9nIkzx01ST/6lRcNatHOgvm+mjR+/Zc7/QIbcQ==
+react-instantsearch-core@7.12.4:
+  version "7.12.4"
+  resolved "https://registry.yarnpkg.com/react-instantsearch-core/-/react-instantsearch-core-7.12.4.tgz#656842d1c639acedf1bf1afdaa0c533ed41febed"
+  integrity sha512-FJn0hFrC3YaZX+y4XkqleHs2lcVXlWP1oCUsvVgwnP7D21iHQLmC0POwzWnJkHk7XJc92xZKVu/jp4mnsieECw==
   dependencies:
     "@babel/runtime" "^7.1.2"
-    algoliasearch-helper "^3.9.0"
-    instantsearch.js "^4.42.0"
+    algoliasearch-helper "3.22.3"
+    instantsearch.js "4.73.4"
     use-sync-external-store "^1.0.0"
+
+react-instantsearch@^7.12.4:
+  version "7.12.4"
+  resolved "https://registry.yarnpkg.com/react-instantsearch/-/react-instantsearch-7.12.4.tgz#935698676ba1a4b3e6c99af6b612e193ad601477"
+  integrity sha512-k/B5v2RKUyFSSusUzAZ7vlyrkEenh6iMdPYiBZ0YMBckYYXVCTcZmTA1sipb8DomT1lOk1QCDLa1QhoLRKNr7Q==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    instantsearch-ui-components "0.8.0"
+    instantsearch.js "4.73.4"
+    react-instantsearch-core "7.12.4"
 
 react-is@18.1.0:
   version "18.1.0"
@@ -15077,6 +15117,11 @@ schema-utils@^4.0.0:
     ajv "^8.9.0"
     ajv-formats "^2.1.1"
     ajv-keywords "^5.1.0"
+
+search-insights@^2.15.0:
+  version "2.16.2"
+  resolved "https://registry.yarnpkg.com/search-insights/-/search-insights-2.16.2.tgz#fba2734124ddf03c00557674eff9bbdc047f4844"
+  integrity sha512-+KrS5rnYlyWgzoCNJGsNPw7Vv+47Y7Ze7KZ+/9Xls+5BUugEbU2yv1n9JsQOqv+MLKYfg3bxI5K6tYJxXZY8FA==
 
 search-insights@^2.6.0:
   version "2.11.0"


### PR DESCRIPTION
# Summary

This PR removes the `@alexjball/react-instantsearch-hooks-web` fork of `react-instantsearch-hooks-web` and replaces it with `react-instantsearch`

This change mainly affects the Bills and Testimonies Search.

# Checklist

- [x] On the frontend, I've made my strings translate-able.
- [ ] If I've added shared components, I've added a storybook story.
- [ ] I've made pages responsive and look good on mobile.

# Screenshots

_Add some screenshots highlighting your changes._

# Known issues

_If you've run against limitations or caveats, include them here. Include follow-up issues as well._

# Steps to test/reproduce

_For each feature or bug fix, create a step by step list for how a reviewer can test it out. E.g.:_

1. Go to the home page
2. Click on Browse All Testimony
3. Filter and sort to see if results are expected

1. Go to the home page
2. Click on Browse Bills
3. Filter and sort to see if results are expected
