### PR TITLE
use followOrg flag to control display of Following Tab on Edit Profil…

### DIFF
--- a/components/EditProfilePage/EditProfilePage.tsx
+++ b/components/EditProfilePage/EditProfilePage.tsx
@@ -121,7 +121,7 @@ export function EditProfileForm({
       )
     },
     {
-      title: "Following",
+      title: t("tabs.following"),
       eventKey: "Following",
       content: <FollowingTab className="mt-3 mb-4" />
     }

--- a/components/EditProfilePage/EditProfilePage.tsx
+++ b/components/EditProfilePage/EditProfilePage.tsx
@@ -1,3 +1,4 @@
+import { useFlags } from "components/featureFlags"
 import { PendingUpgradeBanner } from "components/PendingUpgradeBanner"
 import { useTranslation } from "next-i18next"
 import { useState } from "react"
@@ -125,6 +126,12 @@ export function EditProfileForm({
       content: <FollowingTab className="mt-3 mb-4" />
     }
   ]
+
+  const { followOrg } = useFlags()
+
+  if (followOrg === false) {
+    tabs.splice(2, 1)
+  }
 
   return (
     <>


### PR DESCRIPTION
# Summary

issue #1593

on the Edit Profile tab, the "Following" tab is visible on Dev, but not rendered on Prod and Test

Dev:

![image](https://github.com/user-attachments/assets/6802b6f9-5bee-4af9-b306-07406636259e)

Prod and Test:

![image](https://github.com/user-attachments/assets/025c1cd8-3cbc-47ea-9f75-15fb0383f88c)

# Checklist

- [x] On the frontend, I've made my strings translate-able.
- [N/A] If I've added shared components, I've added a storybook story.
- [N/A ] I've made pages responsive and look good on mobile.

# Known issues

none known atm

# Steps to test/reproduce

1. on a local branch, goto featureFlags.ts
2. on ln 31 change the value to false
3. on the app, navigate to your profile page
4. hit the edit profile button
5. make sure the Following Tab is missing
