### PR TITLE
Merged Notifications Updates

### DIFF
--- a/functions/src/notifications/populateBillNotificationEvents.ts
+++ b/functions/src/notifications/populateBillNotificationEvents.ts
@@ -7,27 +7,10 @@
 import * as functions from "firebase-functions"
 import * as admin from "firebase-admin"
 import { Timestamp } from "../firebase"
-import { BillHistory } from "../bills/types"
+import { BillNotification } from "./types"
 
 // Get a reference to the Firestore database
 const db = admin.firestore()
-
-export type Notification = {
-  type: string
-
-  billCourt: string
-  billId: string
-  billName: string
-
-  billHistory: BillHistory
-
-  testimonyUser: string
-  testimonyPosition: string
-  testimonyContent: string
-  testimonyVersion: number
-
-  updateTime: Timestamp
-}
 
 // Define the populateBillNotificationEvents function
 export const populateBillNotificationEvents = functions.firestore
@@ -49,19 +32,14 @@ export const populateBillNotificationEvents = functions.firestore
     if (documentCreated) {
       console.log("New document created")
 
-      const newNotificationEvent: Notification = {
+      const newNotificationEvent: BillNotification = {
         type: "bill",
 
         billCourt: court,
         billId: newData?.id,
-        billName: newData?.id,
+        billName: newData?.content.Title,
 
         billHistory: newData?.history,
-
-        testimonyUser: "",
-        testimonyPosition: "",
-        testimonyContent: "",
-        testimonyVersion: -1,
 
         updateTime: Timestamp.now()
       }

--- a/functions/src/notifications/populateOrgNotificationEvents.ts
+++ b/functions/src/notifications/populateOrgNotificationEvents.ts
@@ -12,7 +12,7 @@ import { OrgNotification } from "./types"
 // Get a reference to the Firestore database
 const db = admin.firestore()
 
-// Define the populateBillNotificationEvents function
+// Define the populateOrgNotificationEvents function
 export const populateOrgNotificationEvents = functions.firestore
   .document("/users/{userId}/publishedTestimony/{testimonyId}")
   .onWrite(async (snapshot, context) => {
@@ -25,7 +25,6 @@ export const populateOrgNotificationEvents = functions.firestore
 
     const oldData = snapshot.before.data()
     const newData = snapshot.after.data()
-    console.log(newData)
 
     // New testimony added
     if (documentCreated) {

--- a/functions/src/notifications/populateOrgNotificationEvents.ts
+++ b/functions/src/notifications/populateOrgNotificationEvents.ts
@@ -7,7 +7,7 @@
 import * as functions from "firebase-functions"
 import * as admin from "firebase-admin"
 import { Timestamp } from "../firebase"
-import { Notification } from "./populateBillNotificationEvents"
+import { OrgNotification } from "./types"
 
 // Get a reference to the Firestore database
 const db = admin.firestore()
@@ -25,20 +25,20 @@ export const populateOrgNotificationEvents = functions.firestore
 
     const oldData = snapshot.before.data()
     const newData = snapshot.after.data()
+    console.log(newData)
 
     // New testimony added
     if (documentCreated) {
       console.log("New document created")
 
-      const newNotificationEvent: Notification = {
+      const newNotificationEvent: OrgNotification = {
         type: "org",
 
         billCourt: newData?.court.toString(),
         billId: newData?.id,
-        billName: newData?.id,
+        billName: newData?.billTitle,
 
-        billHistory: [],
-
+        orgId: newData?.authorUid,
         testimonyUser: newData?.fullName,
         testimonyPosition: newData?.position,
         testimonyContent: newData?.content,
@@ -63,7 +63,7 @@ export const populateOrgNotificationEvents = functions.firestore
       .where("type", "==", "org")
       .where("billCourt", "==", newData?.court.toString())
       .where("billId", "==", newData?.id)
-      .where("fullName", "==", newData?.fullName)
+      .where("authorUid", "==", newData?.authorUid)
       .get()
 
     console.log(

--- a/functions/src/notifications/populateOrgNotificationEvents.ts
+++ b/functions/src/notifications/populateOrgNotificationEvents.ts
@@ -34,7 +34,7 @@ export const populateOrgNotificationEvents = functions.firestore
         type: "org",
 
         billCourt: newData?.court.toString(),
-        billId: newData?.id,
+        billId: newData?.billId,
         billName: newData?.billTitle,
 
         orgId: newData?.authorUid,
@@ -61,7 +61,7 @@ export const populateOrgNotificationEvents = functions.firestore
       .collection("/notificationEvents")
       .where("type", "==", "org")
       .where("billCourt", "==", newData?.court.toString())
-      .where("billId", "==", newData?.id)
+      .where("billId", "==", newData?.billId)
       .where("authorUid", "==", newData?.authorUid)
       .get()
 

--- a/functions/src/notifications/types.ts
+++ b/functions/src/notifications/types.ts
@@ -1,0 +1,24 @@
+import { BillHistory } from "../bills/types"
+import { Timestamp } from "../firebase"
+
+export interface Notification {
+  type: string
+  updateTime: Timestamp
+  billCourt: string
+  billId: string
+  billName: string
+}
+
+export type BillNotification = Notification & {
+  type: "bill"
+  billHistory: BillHistory
+}
+
+export type OrgNotification = Notification & {
+  type: "org"
+  orgId: string
+  testimonyUser: string
+  testimonyPosition: string
+  testimonyContent: string
+  testimonyVersion: number
+}

--- a/scripts/firebase-admin/backfillBillNotificationEvents.ts
+++ b/scripts/firebase-admin/backfillBillNotificationEvents.ts
@@ -1,6 +1,6 @@
 import { Timestamp } from "functions/src/firebase"
 import { Script } from "./types"
-import { Notification } from "functions/src/notifications/populateBillNotificationEvents"
+import { BillNotification } from "functions/src/notifications/types"
 import { Record, Number } from "runtypes"
 
 const Args = Record({
@@ -23,19 +23,14 @@ export const script: Script = async ({ db, args }) => {
     const data = doc.data()
 
     if (data) {
-      const notificationEvent: Notification = {
+      const notificationEvent: BillNotification = {
         type: "bill",
 
         billCourt: court,
         billId: data.id,
-        billName: data.id,
+        billName: data?.content.Title,
 
         billHistory: data.history,
-
-        testimonyUser: "",
-        testimonyPosition: "",
-        testimonyContent: "",
-        testimonyVersion: -1,
 
         updateTime: Timestamp.now()
       }


### PR DESCRIPTION
# Summary

- Fixed the notificationEvents so that the topicName for organization testimonies are the same
- When testimony is created for a Bill, people subscribed to that Bill will also receive a notification for that testimony

# Checklist

- [ ] On the frontend, I've made my strings translate-able.
- [ ] If I've added shared components, I've added a storybook story.
- [ ] I've made pages responsive and look good on mobile.

# Screenshots

_Add some screenshots highlighting your changes._

# Known issues

_If you've run against limitations or caveats, include them here. Include follow-up issues as well._

# Steps to test/reproduce
1. Follow an organization or a Bill
2. Organization posts testimony or someone posts testimony on a subscribed Bill
3. View Newsfeed

