### PR TITLE
Adding base summary field to bill models

### DIFF
--- a/components/db/bills.ts
+++ b/components/db/bills.ts
@@ -53,6 +53,7 @@ export type Bill = {
   currentCommittee?: CurrentCommittee
   city?: string
   topics?: string[]
+  summary?: string
 }
 
 export function useBill(court: number, id: string) {

--- a/functions/src/bills/types.ts
+++ b/functions/src/bills/types.ts
@@ -315,7 +315,8 @@ export const Bill = withDefaults(
     similar: Array(Id),
     currentCommittee: Optional(CurrentCommittee),
     city: Optional(String),
-    topics: Optional(Array(String))
+    topics: Optional(Array(String)),
+    summary: Optional(String)
   }),
   {
     court: 0,

--- a/scripts/firebase-admin/generateBill.ts
+++ b/scripts/firebase-admin/generateBill.ts
@@ -37,7 +37,8 @@ export const script: Script = async ({ db, args }) => {
       fetchedAt: Timestamp.now(),
       history: [],
       similar: [],
-      topics: []
+      topics: [],
+      summary: "This is the summary"
     }
     console.log(`/generalCourts/${court}/bills/${id}`)
     const billRef = db.collection(`/generalCourts/${court}/bills`).doc(`${id}`)

--- a/stories/organisms/billDetail/MockBillData.tsx
+++ b/stories/organisms/billDetail/MockBillData.tsx
@@ -79,5 +79,6 @@ export const bill: Bill = {
   topics: [
     "Criminal investigation, prosecution, interrogation",
     "Criminal sentencing"
-  ]
+  ],
+  summary: "This is the summary"
 }


### PR DESCRIPTION
# Problem

To start development of our new bill summary front-end features, we need to actually store the generated bill summaries somewhere.

# Summary

This PR adds an optional `summary` field to our bill models that will contain the most recently generated LLM bill summary.

This is meant to give enough of an interface to unblock the front-end work - I expect there may be some additional summary storage to keep a historical archive of generated summaries as part of the actual summary backfill task, but I feel our most common query pattern is likely to just fetch the most recent summary whenever we fetch a bill, so I'd prefer to just keep a copy of that data on the bill itself anyway.

# Checklist

- [na] On the frontend, I've made my strings translate-able.
- [na] If I've added shared components, I've added a storybook story.
- [na] I've made pages responsive and look good on mobile.

# Screenshots

N/A

# Known issues

N/A

# Steps to test/reproduce

1. Go to the Browse Bills and Bill Details page
2. See that it loads correctly
