### PR TITLE
Adding kiminkim724 as CODEOWNER

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @sashamaryl @mertbagt @nesanders @mvictor55 @timblais @alexjball @Mephistic
+* @sashamaryl @mertbagt @nesanders @mvictor55 @timblais @alexjball @Mephistic @kiminkim724


### PR DESCRIPTION
Following up from last hack night - this should add Kimin as a PR approver