### PR TITLE
 Extract translatable strings

### DIFF
--- a/components/HearingsScheduled/HearingsScheduled.tsx
+++ b/components/HearingsScheduled/HearingsScheduled.tsx
@@ -3,6 +3,7 @@ import { Container, Carousel, Spinner } from "react-bootstrap"
 import styled from "styled-components"
 import { Col, Row } from "../bootstrap"
 import { useCalendarEvents } from "./calendarEvents"
+import { useTranslation } from "react-i18next"
 
 export type EventData = {
   index: number
@@ -175,6 +176,7 @@ const CarouselControlPrevIcon = styled.span`
 
 export const HearingsScheduled = () => {
   const [monthIndex, setMonthIndex] = useState(0)
+  const { t } = useTranslation("homepage")
 
   const handleSelect = (
     selectedIndex: number,
@@ -195,7 +197,7 @@ export const HearingsScheduled = () => {
       <Row className="mt-5">
         <Col>
           <div className={`h1 mb-5 text-center text-secondary`}>
-            Hearings Scheduled
+            {t("hearingsScheduled.title")}
           </div>
         </Col>
       </Row>
@@ -264,7 +266,7 @@ export const HearingsScheduled = () => {
                 </EventSection>
               ) : (
                 <section className={`text-center text-secondary`}>
-                  <h2>No Scheduled Events</h2>
+                  <h2>{t("hearingsScheduled.noEvents")}</h2>
                 </section>
               )}
             </>

--- a/components/Legislative/Legislative.tsx
+++ b/components/Legislative/Legislative.tsx
@@ -1,85 +1,57 @@
 import { Container } from "react-bootstrap"
 import { TestimonyCardList } from "components/LearnTestimonyComponents/TestimonyCardComponents"
+import { useTranslation } from "react-i18next"
 
 const LegislativeContent = [
   {
-    title: "Filing",
-    paragraphs: [
-      `A Representative, Senator, or the Governor must file a bill. Constituents can write to their legislators (typically their own  district's House or Senate member) to propose a bill to be filed. This can be done at any time, but is typically done before the start of the legislative session (i.e. before the third Friday in January of odd-numbered years). Bills filed later, during the legislative session, require special approval.`
-    ],
     src: "speaker-podium.svg",
     alt: ""
   },
   {
-    title: "Testimony",
-    paragraphs: [
-      `All stakeholders have the chance to share their thoughts with the legislature by submitting written testimony. Typically, testimony is submitted to the legislative Committee responsible for the bill in advance of their public hearing. You can also deliver oral testimony by attending a hearing or you can reach out to your legislators and speak to them directly.`
-    ],
     src: "mic-with-testify.svg",
     alt: ""
   },
   {
-    title: "Public hearing",
-    paragraphs: [
-      `All bills are formally heard by committees during public hearings which are open to the public and recorded and posted as videos on the legislature's website. While the amount of time available to speak during a public hearing is limited, more detailed comments can be submitted to the committee in written testimony.`
-    ],
     src: "doc-with-arrows-to-people.svg",
     alt: ""
   },
   {
-    title: "Committee reports",
-    paragraphs: [
-      `Committee reports. Committees must file reports on each bill under their consideration after discussing them in Executive Session following the public hearing. This typically occurs before February of the second year of the legislative session (even-numbered years). The goal for proponents of a bill is that the Committee will recommend they "ought to pass" and thereby promote them out of the Committee. Most bills, however are "sent to study," meaning that they will not be passed out of committee in that session. A successful bill may be redrafted or amended by the committee based on testimony received and other deliberations. Many of those bills will be refiled in the next session and can be considered again.`
-    ],
     src: "leg-with-lightbulb.svg",
     alt: ""
   },
   {
-    title: "Three readings",
-    paragraphs: [
-      `Each bill passed out of Committee will be "read" three times by each branch, the House and Senate. This typically entails floor debate of the full chamber and a vote of the Committee on Ways and Means or Steering and Policy.`
-    ],
     src: "speaker-with-leg.svg",
     alt: ""
   },
   {
-    title: "Engrossment and Enactment",
-    paragraphs: [
-      `After the three readings, the bill will be voted on by each of the full chambers (House and Senate), resulting in (if successful) "engrossment" and then "enactment.`
-    ],
     src: "opinions.svg",
     alt: ""
   },
   {
-    title: "Conference Committee",
-    paragraphs: [
-      `If necessary, differences between the House and Senate versions of a bill will be reconciled by a temporary Conference Committee appointed by the House Speaker and Senate President.`
-    ],
     src: "respect-with-blob.svg",
     alt: ""
   },
   {
-    title: "Executive branch",
-    paragraphs: [
-      `Lastly, the Governor is responsible for signing the enacted and reconciled bill into law. The governor can also veto the bill, return it to the Legislature for changes, or take a number of other less-common actions.`
-    ],
     src: "speaker-with-pen.svg",
     alt: ""
   }
 ]
 
 const Legislative = () => {
+  const { t } = useTranslation("learnComponents")
+
   return (
     <Container fluid="md" className="mt-3">
       <h1 className="fw-bold tracking-tighter lh-base">
-        Understanding the Massachusetts Legislative Process
+        {t("legislative.title")}
       </h1>
-      <p className="fs-4 tracking-tight lh-base">
-        Some of the key steps in the legislative process for how most bills
-        become laws in MA.
-      </p>
+      <p className="fs-4 tracking-tight lh-base">{t("legislative.intro")}</p>
       <TestimonyCardList
-        contents={LegislativeContent}
+        contents={LegislativeContent.map((value, index) => ({
+          ...value,
+          title: t(`legislative.content.${index}.title`),
+          paragraphs: [t(`legislative.content.${index}.paragraph`)]
+        }))}
         shouldAlternateImages={false}
       />
     </Container>

--- a/components/publish/ChooseStance.tsx
+++ b/components/publish/ChooseStance.tsx
@@ -9,8 +9,10 @@ import { FormNavigation, Next } from "./NavigationButtons"
 import { setPosition } from "./redux"
 import { StepHeader } from "./StepHeader"
 import { useMediaQuery } from "usehooks-ts"
+import { useTranslation } from "react-i18next"
 
 export const ChooseStance = styled(({ ...rest }) => {
+  const { t } = useTranslation("testimony")
   const { position: currentPosition } = usePublishState()
   const dispatch = useAppDispatch()
   const isMobile = useMediaQuery("(max-width: 768px)")
@@ -22,7 +24,7 @@ export const ChooseStance = styled(({ ...rest }) => {
   const hasPosition = Boolean(currentPosition)
   return (
     <div {...rest}>
-      <StepHeader step={1}>Choose Your Stance</StepHeader>
+      <StepHeader step={1}>{t("submitTestimonyForm.chooseStance")}</StepHeader>
       <Row className="d-flex gap-3 justify-content-center mt-4">
         <Col md={3} xs={12} className="d-flex justify-content-center">
           <PositionButton {...props("endorse")} isMobile={isMobile} />

--- a/components/publish/KeepNote.tsx
+++ b/components/publish/KeepNote.tsx
@@ -3,11 +3,15 @@ import { useState } from "react"
 import { Image, Button, Modal, Col, Row } from "../bootstrap"
 import { Step } from "./redux"
 import { Internal } from "components/links"
+import { Trans, useTranslation } from "react-i18next"
 
 export const KeepNote = (props: { currentStep: Step }) => {
+  const { t } = useTranslation("testimony")
   return (
     <NoteContainer className="p-0">
-      <HeaderContainer>Keep Note</HeaderContainer>
+      <HeaderContainer>
+        {t("submitTestimonyForm.keepNote.header")}
+      </HeaderContainer>
       {props.currentStep == "selectLegislators" ||
       props.currentStep == "write" ? (
         <YourTestimony />
@@ -19,6 +23,7 @@ export const KeepNote = (props: { currentStep: Step }) => {
 }
 
 export const KeepNoteMobile = () => {
+  const { t } = useTranslation("testimony")
   const [showYourTestimony, setShowYourTestimony] = useState(false)
   const [showPublishingToMAPLE, setShowPublishingToMAPLE] = useState(false)
 
@@ -31,12 +36,14 @@ export const KeepNoteMobile = () => {
   return (
     <Col className="py-1">
       <Row xs={12}>
-        <p style={{ fontWeight: "bolder" }}>About MAPLE Testimony</p>
+        <p style={{ fontWeight: "bolder" }}>
+          {t("submitTestimonyForm.keepNote.about")}
+        </p>
       </Row>
 
       <Row xs={12} className="my-3">
         <Button variant="outline-secondary" onClick={handleShowYourTestimony}>
-          How MAPLE Testimonies Work
+          {t("submitTestimonyForm.keepNote.howTestimoniesWork")}
         </Button>
       </Row>
 
@@ -45,13 +52,15 @@ export const KeepNoteMobile = () => {
           variant="outline-secondary"
           onClick={handleShowPublishingToMAPLE}
         >
-          Publishing to MAPLE
+          {t("submitTestimonyForm.keepNote.publishing")}
         </Button>
       </Row>
 
       <Modal show={showYourTestimony} onHide={handleCloseYourTestimony}>
         <Modal.Header closeButton>
-          <Modal.Title>How MAPLE Testimonies Work</Modal.Title>
+          <Modal.Title>
+            {t("submitTestimonyForm.keepNote.howTestimoniesWork")}
+          </Modal.Title>
         </Modal.Header>
         <Modal.Body>
           <YourTestimony />
@@ -60,7 +69,9 @@ export const KeepNoteMobile = () => {
 
       <Modal show={showPublishingToMAPLE} onHide={handleClosePublishingToMAPLE}>
         <Modal.Header closeButton>
-          <Modal.Title>Publishing to MAPLE</Modal.Title>
+          <Modal.Title>
+            {t("submitTestimonyForm.keepNote.publishing")}
+          </Modal.Title>
         </Modal.Header>
         <Modal.Body>
           <PublishingToMAPLE />
@@ -71,6 +82,7 @@ export const KeepNoteMobile = () => {
 }
 
 export const YourTestimony = () => {
+  const { t } = useTranslation("testimony")
   return (
     <NoteContent>
       <div className="text-center">
@@ -81,48 +93,42 @@ export const YourTestimony = () => {
           style={{ transform: "scaleY(0.85)" }}
         />
       </div>
-      <NoteSubtitle>Please keep in mind...</NoteSubtitle>
+      <NoteSubtitle>
+        {t("submitTestimonyForm.keepNote.keepInMind")}
+      </NoteSubtitle>
       <ul>
         <NoteItem>
-          <u>We do not send an email for you.</u> This is a preview of what your
-          email to legislators will look like. On the next page, you will be
-          asked to “send email” which will open your email client (e.g.,
-          Outlook) and populate an email with your testimony.
+          <u>{t("submitTestimonyForm.keepNote.noEmailWarning")}</u>
+          {t("submitTestimonyForm.keepNote.emailPreview")}
         </NoteItem>
-        <NoteItem>
-          Your testimony needs to be shared with the right legislators. Your
-          email “To:” box will be populated with the legislators you add here.
-          We've pre-populated this with the most relevant legislators: 1) the
-          Chairs of the Committee reviewing this bill; and 2) your own
-          legislators.
-        </NoteItem>
-        <NoteItem>
-          When you send this email, you are submitting formal public testimony!
-          As fellow constituents, we thank you for sharing your voice.
-        </NoteItem>
+        <NoteItem>{t("submitTestimonyForm.keepNote.shareEmail")}</NoteItem>
+        <NoteItem>{t("submitTestimonyForm.keepNote.thankYou")}</NoteItem>
       </ul>
     </NoteContent>
   )
 }
 
 export const PublishingToMAPLE = () => {
+  const { t } = useTranslation("testimony")
   return (
     <NoteContent>
       <div className="text-center">
         <Image className="mx-auto" alt="" src="/computertextblob.svg" />
       </div>
-      <NoteSubtitle>Rules for Testimony on MAPLE:</NoteSubtitle>
+      <NoteSubtitle>
+        {t("submitTestimonyForm.keepNote.rulesHeader")}
+      </NoteSubtitle>
       <ul style={{ color: "var(--bs-blue)" }}>
+        <NoteItem>{t("submitTestimonyForm.keepNote.editLimit")}</NoteItem>
         <NoteItem>
-          You can edit your testimony up to 5 times but the previous versions
-          will remain available.
+          <Trans
+            t={t}
+            i18nKey="submitTestimonyForm.keepNote.cannotDelete"
+            // eslint-disable-next-line react/jsx-key
+            components={[<Internal href="/about/faq-page" />]}
+          />
         </NoteItem>
-        <NoteItem>
-          Since MAPLE is an archive, you cannot remove your testimony from the
-          site. You may request a deletion in certain circumstances (see our{" "}
-          <Internal href="/about/faq-page">FAQ page</Internal>)
-        </NoteItem>
-        <NoteItem>Don't forget to send the email to your legislator.</NoteItem>
+        <NoteItem>{t("submitTestimonyForm.keepNote.emailReminder")}</NoteItem>
       </ul>
     </NoteContent>
   )

--- a/components/publish/SelectLegislatorsCta.tsx
+++ b/components/publish/SelectLegislatorsCta.tsx
@@ -1,3 +1,4 @@
+import { Trans, useTranslation } from "react-i18next"
 import { useProfileState } from "../db/profile/redux"
 import { Loading } from "../legislatorSearch"
 import { External } from "../links"
@@ -13,18 +14,24 @@ function useSelectLegislators() {
 }
 
 export const SelectLegislatorsCta = ({ className }: { className?: string }) => {
+  const { t } = useTranslation("testimony")
   const loading = useSelectLegislators()
   return loading ? (
     <Loading />
   ) : (
     <div className={className}>
-      <StepHeader>Select Your Legislators</StepHeader>
+      <StepHeader>
+        {t("submitTestimonyForm.selectLegislators.title")}
+      </StepHeader>
       <p>
-        It looks like you haven't selected your legislators. Please use the{" "}
-        <External href="https://malegislature.gov/Search/FindMyLegislator">
-          find your legislator tool
-        </External>{" "}
-        and select your State Representative and Senator below.
+        <Trans
+          t={t}
+          i18nKey="submitTestimonyForm.selectLegislators.description"
+          components={[
+            // eslint-disable-next-line react/jsx-key
+            <External href="https://malegislature.gov/Search/FindMyLegislator" />
+          ]}
+        />
       </p>
       <SelectLegislators />
       <nav.FormNavigation left={<nav.Previous />} right={<nav.Next />} />

--- a/components/publish/SubmitTestimonyForm.tsx
+++ b/components/publish/SubmitTestimonyForm.tsx
@@ -16,6 +16,9 @@ import { Step } from "./redux"
 import { SelectLegislatorsCta } from "./SelectLegislatorsCta"
 import { ShareTestimony } from "./ShareTestimony"
 import { WriteTestimony } from "./WriteTestimony"
+import { Trans, useTranslation } from "react-i18next"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+import { faCaretDown, faCaretUp } from "@fortawesome/free-solid-svg-icons"
 
 const Background = styled.div`
   background: var(--bs-white);
@@ -74,6 +77,7 @@ const PolicyDetailsStyle = styled.div`
 `
 
 const PolicyDetails = ({ bill, profile }: { bill: Bill; profile: Profile }) => {
+  const { t } = useTranslation("testimony")
   const [isCollapsed, setCollapsed] = useState(false)
 
   return (
@@ -87,9 +91,15 @@ const PolicyDetails = ({ bill, profile }: { bill: Bill; profile: Profile }) => {
 
       <div onClick={() => setCollapsed(!isCollapsed)}>
         {isCollapsed ? (
-          <div>View Less Details &#9650;</div>
+          <div>
+            {t("submitTestimonyForm.viewLess")}
+            <FontAwesomeIcon icon={faCaretUp} />
+          </div>
         ) : (
-          <div>View Bill Details &#9660;</div>
+          <div>
+            {t("submitTestimonyForm.viewMore")}
+            <FontAwesomeIcon icon={faCaretDown} />
+          </div>
         )}
       </div>
     </PolicyDetailsStyle>
@@ -105,6 +115,7 @@ export const Form = ({
   bill: Bill
   synced: boolean
 }) => {
+  const { t } = useTranslation("testimony")
   const content: Record<Step, React.ReactNode> = {
     position: <ChooseStance />,
     selectLegislators: <SelectLegislatorsCta />,
@@ -120,7 +131,7 @@ export const Form = ({
         href={links.maple.bill(bill)}
         className={clsx(!synced && "pe-none")}
       >
-        Back to Bill (Bill {bill.id})
+        {t("submitTestimonyForm.backToBill", { billId: bill.id })}
       </links.Internal>
       <Overview className="mt-3" />
       {isMobile && (step == "write" || step == "publish" || step == "share") ? (
@@ -132,24 +143,24 @@ export const Form = ({
   )
 }
 
-const Overview = ({ className }: { className: string }) => (
-  <div className={clsx("d-flex", className)}>
-    <Row className="align-items-center">
-      <Col md={10} xs={12}>
-        <h1>Write, Publish, and Send Your Testimony!</h1>
-        <Divider className="me-5" />
-        <div className="mt-2" style={{ fontWeight: "bolder" }}>
-          Your voice matters. And it's important that you share it. MAPLE helps
-          you 1) write testimony, 2) publish it to our community, and 3) send it
-          to the right legislators so it can be formally considered. It's easy
-          as 1-2-3!
-        </div>
-      </Col>
-      <Col md={2} xs={12}>
-        <div className="mx-auto text-center">
-          <Image alt="" src="/writing.svg" />
-        </div>
-      </Col>
-    </Row>
-  </div>
-)
+const Overview = ({ className }: { className: string }) => {
+  const { t } = useTranslation("testimony")
+  return (
+    <div className={clsx("d-flex", className)}>
+      <Row className="align-items-center">
+        <Col md={10} xs={12}>
+          <h1>{t("submitTestimonyForm.overview.title")}</h1>
+          <Divider className="me-5" />
+          <div className="mt-2" style={{ fontWeight: "bolder" }}>
+            {t("submitTestimonyForm.overview.description")}
+          </div>
+        </Col>
+        <Col md={2} xs={12}>
+          <div className="mx-auto text-center">
+            <Image alt="" src="/writing.svg" />
+          </div>
+        </Col>
+      </Row>
+    </div>
+  )
+}

--- a/components/publish/WriteTestimony.tsx
+++ b/components/publish/WriteTestimony.tsx
@@ -12,6 +12,7 @@ import { SelectRecipients } from "./SelectRecipients"
 import { StepHeader } from "./StepHeader"
 import { useFormRedirection, usePublishState } from "./hooks"
 import { setAttachmentId, setContent } from "./redux"
+import { Trans, useTranslation } from "react-i18next"
 type TabKey = "text" | "import"
 type UseWriteTestimony = ReturnType<typeof useWriteTestimony>
 
@@ -36,6 +37,7 @@ function useWriteTestimony() {
 }
 
 export const WriteTestimony = styled(props => {
+  const { t } = useTranslation("testimony")
   const write = useWriteTestimony()
   // const tabs = useTabs(write)
 
@@ -43,7 +45,7 @@ export const WriteTestimony = styled(props => {
 
   return (
     <div {...props}>
-      <StepHeader step={2}>Write Your Testimony</StepHeader>
+      <StepHeader step={2}>{t("submitTestimonyForm.write.header")}</StepHeader>
       <SelectRecipients className="my-4" />
 
       <div className="divider" />
@@ -53,21 +55,25 @@ export const WriteTestimony = styled(props => {
           setContent={write.setContent}
           content={write.content}
           error={write.error}
-          label="Testimony"
-          placeholder="Add your testimony here"
-          help="Testimony is limited to 10,000 characters."
+          label={t("submitTestimonyForm.write.testimonyLabel")}
+          placeholder={t("submitTestimonyForm.write.testimonyPlaceholder")}
+          help={t("submitTestimonyForm.write.testimonyHelp")}
           className="text-container"
         />
         <div>
-          Need help? Read our{" "}
-          <links.Internal href="/learn/writing-effective-testimony">
-            testimony writing tips
-          </links.Internal>
+          <Trans
+            t={t}
+            i18nKey="submitTestimonyForm.write.tips"
+            components={[
+              // eslint-disable-next-line react/jsx-key
+              <links.Internal href="/learn/writing-effective-testimony" />
+            ]}
+          />
         </div>
 
         <div>
           <links.Internal href="/policies/code-of-conduct">
-            View our code of conduct
+            {t("submitTestimonyForm.write.codeOfConduct")}
           </links.Internal>
         </div>
 
@@ -105,6 +111,7 @@ const useTabs = ({
   attachmentId,
   attachment: { remove: removeAttachment }
 }: UseWriteTestimony) => {
+  const { t } = useTranslation("testimony")
   const [activeKey, setActiveKey] = useState<TabKey | undefined>()
 
   useEffect(() => {
@@ -117,13 +124,13 @@ const useTabs = ({
     (k: string | null) => {
       const key: TabKey | null = k as TabKey
       if (key === "text" && attachmentId) {
-        if (confirm("Are you sure you want to remove your attachment?"))
+        if (confirm(t("submitTestimonyForm.write.confirmRemoveAttachment")))
           removeAttachment().then(() => setActiveKey(key))
       } else if (key !== null) {
         setActiveKey(key)
       }
     },
-    [attachmentId, removeAttachment]
+    [attachmentId, removeAttachment, t]
   )
 
   return { onSelect, activeKey, loading: activeKey === undefined }

--- a/components/publish/panel/EditTestimonyButton.tsx
+++ b/components/publish/panel/EditTestimonyButton.tsx
@@ -18,7 +18,7 @@ export const EditTestimonyButton = ({
   return (
     <ImageButton
       alt={t("testimonyItem.edit")}
-      tooltip="Edit Testimony"
+      tooltip={t("testimonyItem.edit")}
       src="/edit-testimony.svg"
       href={url}
       className={clsx("testimony-button", className)}

--- a/components/publish/panel/ThankYouModal.tsx
+++ b/components/publish/panel/ThankYouModal.tsx
@@ -4,10 +4,12 @@ import { Image, Modal } from "../../bootstrap"
 import { useAppDispatch } from "../../hooks"
 import { usePublishState } from "../hooks"
 import { setShowThankYou } from "../redux"
+import { useTranslation } from "react-i18next"
 
 const modalDurationMs = 2000
 
 export const ThankYouModal = styled(({ ...rest }) => {
+  const { t } = useTranslation("testimony")
   const show = usePublishState().showThankYou
   const dispatch = useAppDispatch()
   const timeout = useRef<number>(-1)
@@ -43,7 +45,7 @@ export const ThankYouModal = styled(({ ...rest }) => {
       <Modal.Body className=" d-flex align-items-center">
         <Image alt="" src="/leaf-bundle.png" className="leaves-ul" />
         <Image alt="" src="/leaf-bundle.png" className="leaves-br" />
-        <div className="thank-you">Thank You For Submitting Testimony!</div>
+        <div className="thank-you">{t("thankYouModal")}</div>
         <Image alt="" src="/bill-thank-you.svg" />
       </Modal.Body>
     </Modal>

--- a/components/publish/panel/YourTestimony.tsx
+++ b/components/publish/panel/YourTestimony.tsx
@@ -22,6 +22,7 @@ export const YourTestimony = () => {
 }
 
 const MainPanel = styled(({ ...rest }) => {
+  const { t } = useTranslation("testimony")
   const { draft, deleteTestimony, publication } = usePublishService() ?? {}
   const unpublishedDraft = hasDraftChanged(draft, publication)
   const [showConfirm, setShowConfirm] = useState(false)
@@ -30,7 +31,7 @@ const MainPanel = styled(({ ...rest }) => {
   return (
     <div {...rest}>
       <div className="d-flex">
-        <span className="title">Your Testimony</span>
+        <span className="title">{t("yourTestimony.title")}</span>
         <EditTestimonyButton
           className="me-1"
           billId={bill.id}
@@ -48,7 +49,9 @@ const MainPanel = styled(({ ...rest }) => {
       /> */}
       <div className="divider mt-3 mb-3" />
       <TestimonyPreview type="draft" className="mb-2" />
-      {unpublishedDraft && <div className="draft-badge">Draft</div>}
+      {unpublishedDraft && (
+        <div className="draft-badge">{t("yourTestimony.draft")}</div>
+      )}
     </div>
   )
 })`
@@ -122,10 +125,11 @@ const TwitterButton = (props: ClsProps) => {
 }
 
 const EmailButton = (props: ClsProps) => {
+  const { t } = useTranslation("testimony")
   const { publication, bill: { id: billId, court } = {} } = usePublishState()
   return publication ? (
     <Wrap href={formUrl(billId!, court!, "share")}>
-      <Cta {...props}>Email Your Published Testimony </Cta>
+      <Cta {...props}>{t("yourTestimony.emailCta")} </Cta>
     </Wrap>
   ) : null
 }

--- a/components/publish/panel/ctas.tsx
+++ b/components/publish/panel/ctas.tsx
@@ -4,6 +4,7 @@ import styled from "styled-components"
 import { SignInWithButton, useAuth } from "../../auth"
 import { Wrap } from "../../links"
 import { formUrl, usePublishState } from "../hooks"
+import { useTranslation } from "react-i18next"
 
 const Styled = styled.div`
   display: flex;
@@ -49,43 +50,51 @@ const OpenForm = ({ label, ...props }: { label: string } & ButtonProps) => {
   )
 }
 
-export const CreateTestimony = () => (
-  <Cta
-    title="You Haven't Submitted Testimony"
-    cta={<OpenForm label="Create Testimony" />}
-  />
-)
+export const CreateTestimony = () => {
+  const { t } = useTranslation("testimony")
 
-export const CompleteTestimony = () => (
-  <Cta
-    title="You Have Draft Testimony"
-    cta={
-      <OpenForm
-        label="Complete Testimony"
-        variant="info"
-        className="text-white"
-      />
-    }
-    className="text-info"
-  />
-)
+  return (
+    <Cta
+      title={t("panel.createTestimony.title")}
+      cta={<OpenForm label={t("panel.createTestimony.label")} />}
+    />
+  )
+}
 
-export const SignedOut = () => (
-  <Cta
-    title="Sign In to Add Testimony"
-    cta={<SignInWithButton label="Sign In/Sign Up" />}
-  />
-)
+export const CompleteTestimony = () => {
+  const { t } = useTranslation("testimony")
+
+  return (
+    <Cta
+      title={t("panel.completeTestimony.title")}
+      cta={
+        <OpenForm
+          label={t("panel.completeTestimony.label")}
+          variant="info"
+          className="text-white"
+        />
+      }
+      className="text-info"
+    />
+  )
+}
+
+export const SignedOut = () => {
+  const { t } = useTranslation("testimony")
+
+  return <Cta title={t("panel.signedOut.title")} cta={<SignInWithButton />} />
+}
 
 export const UnverifiedEmail = () => {
+  const { t } = useTranslation("testimony")
   const id = useAuth().user?.uid!
 
   return (
     <Cta
-      title="Verify Your Email to Add Testimony"
+      title={t("panel.unverifiedEmail.title")}
       cta={
         <Wrap href={`/profile?id=${id}`}>
-          <Button variant="primary">Verify Your Email</Button>
+          <Button variant="primary">{t("panel.unverifiedEmail.label")}</Button>
         </Wrap>
       }
     />
@@ -93,12 +102,14 @@ export const UnverifiedEmail = () => {
 }
 
 export const PendingUpgrade = () => {
+  const { t } = useTranslation("testimony")
+
   return (
     <Cta
-      title="Pending Upgrade"
+      title={t("panel.pendingUpgrade.title")}
       cta={
         <Button variant="primary" disabled>
-          Your Organization Registration is Pending
+          {t("panel.pendingUpgrade.label")}
         </Button>
       }
     />

--- a/components/table/PaginationButtons.tsx
+++ b/components/table/PaginationButtons.tsx
@@ -8,6 +8,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { Button } from "../bootstrap"
 import { Pagination } from "../db"
 import styled from "styled-components"
+import { useTranslation } from "react-i18next"
 
 export const PaginationButtons = ({
   pagination: {
@@ -23,6 +24,8 @@ export const PaginationButtons = ({
   pagination: Pagination
   totalItems: number | undefined
 }) => {
+  const { t } = useTranslation("common")
+
   if (totalItems === undefined) {
     return null
   }
@@ -38,7 +41,7 @@ export const PaginationButtons = ({
         <FontAwesomeIcon icon={faAngleDoubleLeft} />
       </PreviousStyle>
       <SpanStyle variant="secondary" className="align-self-center">
-        Page {currentPage}
+        {t("table.page", { currentPage })}
       </SpanStyle>
       <NextStyle
         variant="secondary"

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -72,5 +72,8 @@
     "linkedin": "LinkedIn",
     "twitter": "Twitter",
     "facebook":"Facebook"
+  },
+  "table": {
+    "page": "Page {{currentPage}}"
   }
 }

--- a/public/locales/en/homepage.json
+++ b/public/locales/en/homepage.json
@@ -1,5 +1,9 @@
 {
   "About_MAPLE": "About MAPLE",
+  "hearingsScheduled": {
+    "noEvents": "No Scheduled Events",
+    "title": "Hearings Scheduled"
+  },
   "who": {
     "title": "Who",
     "bodytext": "All Massachusetts residents can use MAPLE to fulfill their civic responsibility to our state democracy."

--- a/public/locales/en/learnComponents.json
+++ b/public/locales/en/learnComponents.json
@@ -100,15 +100,15 @@
         "paragraph": "All stakeholders have the chance to share their thoughts with the legislature by submitting written testimony. Typically, testimony is submitted to the legislative Committee responsible for the bill in advance of their public hearing. You can also deliver oral testimony by attending a hearing or you can reach out to your legislators and speak to them directly."
       },
       {
-        "title": "Public hearing",
+        "title": "Public Hearing",
         "paragraph": "All bills are formally heard by committees during public hearings which are open to the public and recorded and posted as videos on the legislature's website. While the amount of time available to speak during a public hearing is limited, more detailed comments can be submitted to the committee in written testimony."
       },
       {
-        "title": "Committee reports",
+        "title": "Committee Reports",
         "paragraph": "Committee reports. Committees must file reports on each bill under their consideration after discussing them in Executive Session following the public hearing. This typically occurs before February of the second year of the legislative session (even-numbered years). The goal for proponents of a bill is that the Committee will recommend they \"ought to pass\" and thereby promote them out of the Committee. Most bills, however are \"sent to study,\" meaning that they will not be passed out of committee in that session. A successful bill may be redrafted or amended by the committee based on testimony received and other deliberations. Many of those bills will be refiled in the next session and can be considered again."
       },
       {
-        "title": "Three readings",
+        "title": "Three Readings",
         "paragraph": "Each bill passed out of Committee will be \"read\" three times by each branch, the House and Senate. This typically entails floor debate of the full chamber and a vote of the Committee on Ways and Means or Steering and Policy."
       },
       {
@@ -120,7 +120,7 @@
         "paragraph": "If necessary, differences between the House and Senate versions of a bill will be reconciled by a temporary Conference Committee appointed by the House Speaker and Senate President."
       },
       {
-        "title": "Executive branch",
+        "title": "Executive Branch",
         "paragraph": "Lastly, the Governor is responsible for signing the enacted and reconciled bill into law. The governor can also veto the bill, return it to the Legislature for changes, or take a number of other less-common actions."
       }
     ]

--- a/public/locales/en/learnComponents.json
+++ b/public/locales/en/learnComponents.json
@@ -86,5 +86,43 @@
     "testifyInWriting": "Testify in writing",
     "testifyOrally": "Testify orally",
     "writeOrCall": "Write or call them"
+  },
+  "legislative": {
+    "title": "Understanding the Massachusetts Legislative Process",
+    "intro": "Some of the key steps in the legislative process for how most bills become laws in MA.",
+    "content": [
+      {
+        "title": "Filing",
+        "paragraph": "A Representative, Senator, or the Governor must file a bill. Constituents can write to their legislators (typically their own  district's House or Senate member) to propose a bill to be filed. This can be done at any time, but is typically done before the start of the legislative session (i.e. before the third Friday in January of odd-numbered years). Bills filed later, during the legislative session, require special approval."
+      },
+      {
+        "title": "Testimony",
+        "paragraph": "All stakeholders have the chance to share their thoughts with the legislature by submitting written testimony. Typically, testimony is submitted to the legislative Committee responsible for the bill in advance of their public hearing. You can also deliver oral testimony by attending a hearing or you can reach out to your legislators and speak to them directly."
+      },
+      {
+        "title": "Public hearing",
+        "paragraph": "All bills are formally heard by committees during public hearings which are open to the public and recorded and posted as videos on the legislature's website. While the amount of time available to speak during a public hearing is limited, more detailed comments can be submitted to the committee in written testimony."
+      },
+      {
+        "title": "Committee reports",
+        "paragraph": "Committee reports. Committees must file reports on each bill under their consideration after discussing them in Executive Session following the public hearing. This typically occurs before February of the second year of the legislative session (even-numbered years). The goal for proponents of a bill is that the Committee will recommend they \"ought to pass\" and thereby promote them out of the Committee. Most bills, however are \"sent to study,\" meaning that they will not be passed out of committee in that session. A successful bill may be redrafted or amended by the committee based on testimony received and other deliberations. Many of those bills will be refiled in the next session and can be considered again."
+      },
+      {
+        "title": "Three readings",
+        "paragraph": "Each bill passed out of Committee will be \"read\" three times by each branch, the House and Senate. This typically entails floor debate of the full chamber and a vote of the Committee on Ways and Means or Steering and Policy."
+      },
+      {
+        "title": "Engrossment and Enactment",
+        "paragraph": "After the three readings, the bill will be voted on by each of the full chambers (House and Senate), resulting in (if successful) \"engrossment\" and then \"enactment.\""
+      },
+      {
+        "title": "Conference Committee",
+        "paragraph": "If necessary, differences between the House and Senate versions of a bill will be reconciled by a temporary Conference Committee appointed by the House Speaker and Senate President."
+      },
+      {
+        "title": "Executive branch",
+        "paragraph": "Lastly, the Governor is responsible for signing the enacted and reconciled bill into law. The governor can also veto the bill, return it to the Legislature for changes, or take a number of other less-common actions."
+      }
+    ]
   }
 }

--- a/public/locales/en/testimony.json
+++ b/public/locales/en/testimony.json
@@ -97,6 +97,7 @@
       }
     }
   },
+  "thankYouModal": "Thank You For Submitting Testimony!",
   "userFilterDropdown": {
     "publishedTestimonies": "All Published Testimonies",
     "usersOnly": "Users Only",

--- a/public/locales/en/testimony.json
+++ b/public/locales/en/testimony.json
@@ -111,5 +111,10 @@
     "showing1": "Showing 1 - ",
     "outOf": " out of ",
     "noTestimonies": "There are no testimonies "
+  },
+  "yourTestimony": {
+    "title": "Your Testimony",
+    "draft": "Draft",
+    "emailCta": "Email Your Published Testimony"
   }
 }

--- a/public/locales/en/testimony.json
+++ b/public/locales/en/testimony.json
@@ -90,6 +90,21 @@
     "selectLegislators": {
       "title": "Select Your Legislators",
       "description": "It looks like you haven't selected your legislators. Please use the <0>find your legislator tool</0> and select your State Representative and Senator below."
+    },
+    "keepNote": {
+      "header": "Keep Note",
+      "about": "About MAPLE Testimony",
+      "howTestimoniesWork": "How MAPLE Testimonies Work",
+      "publishing": "Publishing to MAPLE",
+      "keepInMind": "Please keep in mind...",
+      "noEmailWarning": "We do not send an email for you.",
+      "emailPreview": " This is a preview of what your email to legislators will look like. On the next page, you will be asked to “send email” which will open your email client (e.g., Outlook) and populate an email with your testimony.",
+      "shareEmail": "Your testimony needs to be shared with the right legislators. Your email “To:” box will be populated with the legislators you add here. We've pre-populated this with the most relevant legislators: 1) the Chairs of the Committee reviewing this bill; and 2) your own legislators.",
+      "thankYou": "When you send this email, you are submitting formal public testimony! As fellow constituents, we thank you for sharing your voice.",
+      "rulesHeader": "Rules for Testimony on MAPLE:",
+      "editLimit": "You can edit your testimony up to 5 times but the previous versions will remain available.",
+      "cannotDelete": "Since MAPLE is an archive, you cannot remove your testimony from the site. You may request a deletion in certain circumstances (see our <0>FAQ page</0>)",
+      "emailReminder": "Don't forget to send the email to your legislator."
     }
   },
   "testimonyItem": {

--- a/public/locales/en/testimony.json
+++ b/public/locales/en/testimony.json
@@ -85,7 +85,8 @@
     "overview": {
       "title": "Write, Publish, and Send Your Testimony!",
       "description": "Your voice matters. And it's important that you share it. MAPLE helps you 1) write testimony, 2) publish it to our community, and 3) send it to the right legislators so it can be formally considered. It's easy as 1-2-3!"
-    }
+    },
+    "chooseStance": "Choose Your Stance"
   },
   "testimonyItem": {
     "deleteTestimonyConfirmation": "Are you sure you want to delete your testimony?",

--- a/public/locales/en/testimony.json
+++ b/public/locales/en/testimony.json
@@ -8,6 +8,27 @@
     "tweetContent": "I provided testimony on Bill {{billNumber}}. See {{link}} for details.",
     "twitter": "Tweet Your Published Testimony"
   },
+  "panel": {
+    "createTestimony": {
+      "title": "You Haven't Submitted Testimony",
+      "label": "Create Testimony"
+    },
+    "completeTestimony": {
+      "title": "You Have Draft Testimony",
+      "label": "Complete Testimony"
+    },
+    "pendingUpgrade": {
+      "title": "Pending Upgrade",
+      "label": "Your Organization Registration is Pending"
+    },
+    "signedOut": {
+      "title": "Sign In to Add Testimony"
+    },
+    "unverifiedEmail": {
+      "title": "Verify Your Email to Add Testimony",
+      "label": "Verify Your Email"
+    }
+  },
   "testimonyDetail": {
     "what": "What",
     "says": "says",

--- a/public/locales/en/testimony.json
+++ b/public/locales/en/testimony.json
@@ -105,6 +105,15 @@
       "editLimit": "You can edit your testimony up to 5 times but the previous versions will remain available.",
       "cannotDelete": "Since MAPLE is an archive, you cannot remove your testimony from the site. You may request a deletion in certain circumstances (see our <0>FAQ page</0>)",
       "emailReminder": "Don't forget to send the email to your legislator."
+    },
+    "write": {
+      "header": "Write Your Testimony",
+      "testimonyLabel": "Testimony",
+      "testimonyPlaceholder": "Add your testimony here",
+      "testimonyHelp": "Testimony is limited to 10,000 characters.",
+      "tips": "Need help? Read our <0>testimony writing tips</0>",
+      "codeOfConduct": "View our code of conduct",
+      "confirmRemoveAttachment": "Are you sure you want to remove your attachment?"
     }
   },
   "testimonyItem": {

--- a/public/locales/en/testimony.json
+++ b/public/locales/en/testimony.json
@@ -78,6 +78,15 @@
     "recentFirst": "Most Recent First",
     "oldestFirst": "Oldest First"
   },
+  "submitTestimonyForm": {
+    "viewLess": "View Less Details",
+    "viewMore": "View Bill Details",
+    "backToBill": "Back to Bill (Bill {{billId}})",
+    "overview": {
+      "title": "Write, Publish, and Send Your Testimony!",
+      "description": "Your voice matters. And it's important that you share it. MAPLE helps you 1) write testimony, 2) publish it to our community, and 3) send it to the right legislators so it can be formally considered. It's easy as 1-2-3!"
+    }
+  },
   "testimonyItem": {
     "deleteTestimonyConfirmation": "Are you sure you want to delete your testimony?",
     "no": "No",

--- a/public/locales/en/testimony.json
+++ b/public/locales/en/testimony.json
@@ -86,7 +86,11 @@
       "title": "Write, Publish, and Send Your Testimony!",
       "description": "Your voice matters. And it's important that you share it. MAPLE helps you 1) write testimony, 2) publish it to our community, and 3) send it to the right legislators so it can be formally considered. It's easy as 1-2-3!"
     },
-    "chooseStance": "Choose Your Stance"
+    "chooseStance": "Choose Your Stance",
+    "selectLegislators": {
+      "title": "Select Your Legislators",
+      "description": "It looks like you haven't selected your legislators. Please use the <0>find your legislator tool</0> and select your State Representative and Senator below."
+    }
   },
   "testimonyItem": {
     "deleteTestimonyConfirmation": "Are you sure you want to delete your testimony?",


### PR DESCRIPTION
# Summary

This PR extracts translatable strings from a few of our outstanding components (as determined by our lint rule). I had a little free time and figured I could chip away at a few of these.

# Checklist

- [x] On the frontend, I've made my strings translate-able.
- [na] If I've added shared components, I've added a storybook story.
- [na] I've made pages responsive and look good on mobile.

# Screenshots

N/A (No visible changes)

# Known issues

N/A

# Steps to test/reproduce
There should be no visible changes for any of these 
1. Go to the home page and check the HearingsScheduled section
2. Go to the Bill Details page for a bill and check the "Submit Testimony" section
3. Go through the Submit Testimony flow
4. Go to the learn page for the Legislative Process
