### PR TITLE
Bill Topic Updates

### DIFF
--- a/components/db/bills.ts
+++ b/components/db/bills.ts
@@ -36,6 +36,11 @@ export type BillContent = {
   DocumentText: string
 }
 
+export type BillTopic = {
+  category: string
+  topic: string
+}
+
 export type Bill = {
   id: string
   court: number
@@ -52,7 +57,7 @@ export type Bill = {
   history: BillHistory
   currentCommittee?: CurrentCommittee
   city?: string
-  topics?: string[]
+  topics?: BillTopic[]
   summary?: string
 }
 

--- a/functions/src/bills/topicParser.test.ts
+++ b/functions/src/bills/topicParser.test.ts
@@ -1,0 +1,26 @@
+import { assignCategoriesToTopics } from "./topicParser"
+
+describe("assignCategoriesToTopics", () => {
+  it("assigns categories to topics", () => {
+    const topics = [
+      "Consumer protection",
+      "Correctional facilities",
+      "Property crimes"
+    ]
+    const categories = assignCategoriesToTopics(topics)
+    expect(categories).toEqual([
+      { category: "Commerce", topic: "Consumer protection" },
+      {
+        category: "Crime and Law Enforcement",
+        topic: "Correctional facilities"
+      },
+      { category: "Crime and Law Enforcement", topic: "Property crimes" }
+    ])
+  })
+
+  it("ignores topics with missing categories", () => {
+    const topics = ["Consumer protection", "Unknown topic"]
+    const categories = assignCategoriesToTopics(topics)
+    expect(categories).toEqual([{ category: "Commerce", topic: "Consumer protection" }])
+  })
+})

--- a/functions/src/bills/topicParser.test.ts
+++ b/functions/src/bills/topicParser.test.ts
@@ -21,6 +21,8 @@ describe("assignCategoriesToTopics", () => {
   it("ignores topics with missing categories", () => {
     const topics = ["Consumer protection", "Unknown topic"]
     const categories = assignCategoriesToTopics(topics)
-    expect(categories).toEqual([{ category: "Commerce", topic: "Consumer protection" }])
+    expect(categories).toEqual([
+      { category: "Commerce", topic: "Consumer protection" }
+    ])
   })
 })

--- a/functions/src/bills/topicParser.ts
+++ b/functions/src/bills/topicParser.ts
@@ -1,0 +1,15 @@
+import { BillTopic, CATEGORIES_BY_TOPIC } from "./types"
+
+// The ML model will return a list of topics without categories
+// We need to enrich the topics with the associated topic categories for the hierachical facets
+export const assignCategoriesToTopics = (billTopics: string[]) => {
+    return billTopics.reduce((acc, topic) => {
+        const category = CATEGORIES_BY_TOPIC[topic]
+        if (category) {
+            acc.push({ category, topic })
+        } else {
+          console.error(`No category found for topic ${topic}`)
+        } 
+        return acc
+    }, [] as BillTopic[])
+}

--- a/functions/src/bills/topicParser.ts
+++ b/functions/src/bills/topicParser.ts
@@ -3,13 +3,13 @@ import { BillTopic, CATEGORIES_BY_TOPIC } from "./types"
 // The ML model will return a list of topics without categories
 // We need to enrich the topics with the associated topic categories for the hierachical facets
 export const assignCategoriesToTopics = (billTopics: string[]) => {
-    return billTopics.reduce((acc, topic) => {
-        const category = CATEGORIES_BY_TOPIC[topic]
-        if (category) {
-            acc.push({ category, topic })
-        } else {
-          console.error(`No category found for topic ${topic}`)
-        } 
-        return acc
-    }, [] as BillTopic[])
+  return billTopics.reduce((acc, topic) => {
+    const category = CATEGORIES_BY_TOPIC[topic]
+    if (category) {
+      acc.push({ category, topic })
+    } else {
+      console.error(`No category found for topic ${topic}`)
+    }
+    return acc
+  }, [] as BillTopic[])
 }

--- a/functions/src/bills/types.ts
+++ b/functions/src/bills/types.ts
@@ -49,6 +49,12 @@ export const BillContent = Record({
   Cosponsors: Array(Record({ Name: Maybe(String) }))
 })
 
+export type BillTopic = Static<typeof BillTopic>
+export const BillTopic = Record({
+  category: String,
+  topic: String
+})
+
 /** Represents a missing timestamp value. This allows documents without values
  * to appear in results when sorting by that value. */
 export const MISSING_TIMESTAMP = Timestamp.fromMillis(0)
@@ -315,7 +321,7 @@ export const Bill = withDefaults(
     similar: Array(Id),
     currentCommittee: Optional(CurrentCommittee),
     city: Optional(String),
-    topics: Optional(Array(String)),
+    topics: Optional(Array(BillTopic)),
     summary: Optional(String)
   }),
   {

--- a/stories/organisms/billDetail/MockBillData.tsx
+++ b/stories/organisms/billDetail/MockBillData.tsx
@@ -55,6 +55,17 @@ export const newBillContent: BillContent = {
   DocumentText: "this is the document text"
 }
 
+export const newBillTopics = [
+  {
+    category: "Crime and Law Enforcement",
+    topic: "Criminal investigation, prosecution, interrogation"
+  },
+  {
+    category: "Economics and Public Finance",
+    topic: "Budget process"
+  }
+]
+
 export const bill: Bill = {
   id: "123",
   court: 192,
@@ -76,9 +87,6 @@ export const bill: Bill = {
     }
   },
   city: "Boston",
-  topics: [
-    "Criminal investigation, prosecution, interrogation",
-    "Criminal sentencing"
-  ],
+  topics: newBillTopics,
   summary: "This is the summary"
 }


### PR DESCRIPTION
# Summary

A few updates for the Bill Topic model:
* Adding the topic category to the bill object (to make it available to the front-end and to reduce the number of places we need to do the topic -> category lookup).
  * We should ultimately only need this lookup when we run the ML model (since that will only output the topics, not the categories) - but that code isn't in place yet, so this is mostly prep work
* Extracting the topic -> category mapping out into a helper class + adding unit tests for that logic

@mertbagt This PR includes the data changes we talked about.

# Checklist

- [na] On the frontend, I've made my strings translate-able.
- [na] If I've added shared components, I've added a storybook story.
- [na] I've made pages responsive and look good on mobile.

# Screenshots

N/A

# Known issues

N/A

# Steps to test/reproduce

N/A
