### PR TITLE
Create notificationEvent on BillHistory Updates

### DIFF
--- a/components/Newsfeed/NotificationProps.tsx
+++ b/components/Newsfeed/NotificationProps.tsx
@@ -11,10 +11,10 @@ export type NotificationProps = {
   topicName: string
   timestamp: Timestamp
   createdAt: Timestamp
-  position: string
+  position?: string
   isBillMatch: boolean
   isUserMatch: boolean
-  authorUid: string
+  authorUid?: string
 }
 
 export type Notifications = NotificationProps[]

--- a/components/Newsfeed/NotificationProps.tsx
+++ b/components/Newsfeed/NotificationProps.tsx
@@ -14,6 +14,7 @@ export type NotificationProps = {
   position: string
   isBillMatch: boolean
   isUserMatch: boolean
+  authorUid: string
 }
 
 export type Notifications = NotificationProps[]

--- a/functions/src/notifications/publishNotifications.ts
+++ b/functions/src/notifications/publishNotifications.ts
@@ -22,6 +22,7 @@ const createNotificationFields = (
   let bodyText: string
   let subheader: string
   let position: string | undefined
+  let authorUid: string | undefined
 
   switch (entity.type) {
     case "bill":
@@ -38,6 +39,7 @@ const createNotificationFields = (
       bodyText = entity.testimonyContent
       subheader = entity.testimonyUser
       position = entity.testimonyPosition
+      authorUid = entity.userId
       break
 
     default:
@@ -58,7 +60,8 @@ const createNotificationFields = (
       position: position ?? "",
       isBillMatch: false,
       isUserMatch: false,
-      delivered: false
+      delivered: false,
+      authorUid: authorUid ?? ""
     },
     createdAt: Timestamp.now()
   }

--- a/functions/src/notifications/publishNotifications.ts
+++ b/functions/src/notifications/publishNotifications.ts
@@ -9,6 +9,7 @@ import * as admin from "firebase-admin"
 import { Timestamp } from "../firebase"
 import {
   BillHistoryUpdateNotification,
+  NotificationFields,
   TestimonySubmissionNotification
 } from "./types"
 import { cloneDeep } from "lodash"
@@ -18,7 +19,7 @@ const db = admin.firestore()
 
 const createNotificationFields = (
   entity: BillHistoryUpdateNotification | TestimonySubmissionNotification
-) => {
+): NotificationFields => {
   let bodyText: string
   let subheader: string
   let position: string | undefined
@@ -57,11 +58,11 @@ const createNotificationFields = (
       subheader: subheader,
       timestamp: entity.updateTime,
       type: entity.type,
-      position: position ?? "",
+      position: position,
       isBillMatch: false,
       isUserMatch: false,
       delivered: false,
-      authorUid: authorUid ?? ""
+      authorUid: authorUid
     },
     createdAt: Timestamp.now()
   }

--- a/functions/src/notifications/types.ts
+++ b/functions/src/notifications/types.ts
@@ -22,3 +22,22 @@ export type TestimonySubmissionNotification = Notification & {
   testimonyContent: string
   testimonyVersion: number
 }
+
+export interface NotificationFields {
+  uid: string
+  notification: {
+    bodyText: string
+    header: string
+    court: string
+    id: string
+    subheader: string
+    timestamp: FirebaseFirestore.Timestamp
+    type: string
+    position?: string
+    isBillMatch: boolean
+    isUserMatch: boolean
+    delivered: boolean
+    authorUid?: string
+  }
+  createdAt: FirebaseFirestore.Timestamp
+}

--- a/scripts/firebase-admin/updateHistory.ts
+++ b/scripts/firebase-admin/updateHistory.ts
@@ -12,7 +12,7 @@ export const script: Script = async ({ db, args }) => {
       history: FieldValue.arrayUnion({
         Action: "Placed on file",
         Branch: "Senate",
-        Date: Timestamp.now().valueOf()
+        Date: Timestamp.now().toDate().toISOString()
       })
     })
     console.log("Updated history", id)


### PR DESCRIPTION
# Summary

- Updated Bill History Notification Event trigger, so that it will create a notificationEvent if there isn't one already
  - Also updated the code so that it will only create a notificationEvent if the history has changed. This is for cases when a person follows a bill and testimony is posted to a bill without a notificationEvent, so it will only create a notification Event for the testimony.

# Checklist

- [ ] On the frontend, I've made my strings translate-able.
- [ ] If I've added shared components, I've added a storybook story.
- [ ] I've made pages responsive and look good on mobile.

# Screenshots

# Known issues

_If you've run against limitations or caveats, include them here. Include follow-up issues as well._

# Steps to test/reproduce

_For each feature or bug fix, create a step by step list for how a reviewer can test it out. E.g.:_

1. Follow a Bill without a notificationEvent
2. Update the Bill History
