### PR TITLE
Updated PolicyActions.tsx with Follow/Unfollow functionality

### DIFF
--- a/components/api/bills.ts
+++ b/components/api/bills.ts
@@ -1,0 +1,12 @@
+import { httpsCallable } from "firebase/functions";
+import { functions } from "../firebase"; // Path to Firebase initialization
+
+export async function followBill(data: { court: number; id: string }) {
+  const callable = httpsCallable(functions, "followBill");
+  return callable(data);
+}
+
+export async function unfollowBill(data: { court: number; id: string }) {
+  const callable = httpsCallable(functions, "unfollowBill");
+  return callable(data);
+}

--- a/components/testimony/TestimonyDetailPage/PolicyActions.tsx
+++ b/components/testimony/TestimonyDetailPage/PolicyActions.tsx
@@ -25,7 +25,7 @@ export const PolicyActions: FC<React.PropsWithChildren<PolicyActionsProps>> = ({
   isReporting,
   setReporting,
 }) => {
-  const { bill } = useCurrentTestimonyDetails(),
+  const { bill } = useCurrentTestimonyDetails(), 
     billLabel = formatBillId(bill.id);
   const { notifications } = useFlags();
 

--- a/components/testimony/TestimonyDetailPage/PolicyActions.tsx
+++ b/components/testimony/TestimonyDetailPage/PolicyActions.tsx
@@ -1,58 +1,84 @@
-import { Card, ListItem, ListItemProps } from "components/Card"
-import { useFlags } from "components/featureFlags"
-import { formatBillId } from "components/formatting"
-import { formUrl } from "components/publish"
-import { isNotNull } from "components/utils"
-import { FC, ReactElement } from "react"
-import { useCurrentTestimonyDetails } from "./testimonyDetailSlice"
-import { useTranslation } from "next-i18next"
+import { Card, ListItem, ListItemProps } from "components/Card";
+import { useFlags } from "components/featureFlags";
+import { formatBillId } from "components/formatting";
+import { formUrl } from "components/publish";
+import { isNotNull } from "components/utils";
+import { FC, ReactElement, useState, useEffect } from "react";
+import { useCurrentTestimonyDetails } from "./testimonyDetailSlice";
+import { useTranslation } from "next-i18next";
+import { followBill, unfollowBill } from "../api/bills"; // Adjust the import path as needed
 
 interface PolicyActionsProps {
-  className?: string
-  isUser?: boolean
-  isReporting: boolean
-  setReporting: (boolean: boolean) => void
+  className?: string;
+  isUser?: boolean;
+  isReporting: boolean;
+  setReporting: (boolean: boolean) => void;
 }
 
-const PolicyActionItem: FC<React.PropsWithChildren<ListItemProps>> = props => (
+const PolicyActionItem: FC<React.PropsWithChildren<ListItemProps>> = (props) => (
   <ListItem action active={false} variant="secondary" {...props} />
-)
+);
 
 export const PolicyActions: FC<React.PropsWithChildren<PolicyActionsProps>> = ({
   className,
   isUser,
   isReporting,
-  setReporting
+  setReporting,
 }) => {
   const { bill } = useCurrentTestimonyDetails(),
-    billLabel = formatBillId(bill.id)
-  const { notifications } = useFlags()
+    billLabel = formatBillId(bill.id);
+  const { notifications } = useFlags();
 
-  const items: ReactElement[] = []
-  if (notifications)
-    items.push(
-      <PolicyActionItem
-        onClick={() => window.alert("TODO")} // TODO: add follow action here
-        key="follow"
-        billName={`Follow ${billLabel}`}
-      />
-    )
-  items.push(
+  const [isFollowing, setIsFollowing] = useState(false); // Track follow state
+  const [loading, setLoading] = useState(false); // Track loading state
+
+  // Fetch initial follow state
+  useEffect(() => {
+    const userIsFollowing = bill.followers?.includes("currentUserId"); // Replace "currentUserId" with actual user ID logic
+    setIsFollowing(userIsFollowing || false);
+  }, [bill]);
+
+  const handleFollowToggle = async () => {
+    setLoading(true);
+    try {
+      if (isFollowing) {
+        await unfollowBill({ court: bill.court, id: bill.id }); // Backend call to unfollow
+      } else {
+        await followBill({ court: bill.court, id: bill.id }); // Backend call to follow
+      }
+      setIsFollowing(!isFollowing); // Toggle state
+    } catch (error) {
+      console.error("Error toggling follow state:", error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const items: ReactElement[] = [
+    notifications && (
+      <div key="follow" className="follow-button-container">
+        <button disabled={loading} onClick={handleFollowToggle}>
+          {loading
+            ? "Loading..."
+            : isFollowing
+            ? `Unfollow ${billLabel}`
+            : `Follow ${billLabel}`}
+        </button>
+      </div>
+    ),
     <PolicyActionItem
       key="report-testimony"
-      billName={`Report Testimony`}
+      billName="Report Testimony"
       onClick={() => setReporting(!isReporting)}
-    />
-  )
-  items.push(
+    />,
     <PolicyActionItem
       key="add-testimony"
       billName={`${isUser ? "Edit" : "Add"} Testimony for ${billLabel}`}
       href={formUrl(bill.id, bill.court)}
-    />
-  )
+    />,
+  ].filter(isNotNull);
 
-  const { t } = useTranslation("testimony")
+  const { t } = useTranslation("testimony");
 
   return (
     <Card
@@ -60,5 +86,5 @@ export const PolicyActions: FC<React.PropsWithChildren<PolicyActionsProps>> = ({
       header={t("policyActions.actions") ?? "Actions"}
       items={items}
     />
-  )
-}
+  );
+};

--- a/components/testimony/TestimonyDetailPage/PolicyActions.tsx
+++ b/components/testimony/TestimonyDetailPage/PolicyActions.tsx
@@ -6,7 +6,7 @@ import { isNotNull } from "components/utils";
 import { FC, ReactElement, useState, useEffect } from "react";
 import { useCurrentTestimonyDetails } from "./testimonyDetailSlice";
 import { useTranslation } from "next-i18next";
-import { followBill, unfollowBill } from "../api/bills"; // Adjust the import path as needed
+import { followBill, unfollowBill } from "../../api/bills";
 
 interface PolicyActionsProps {
   className?: string;


### PR DESCRIPTION
# Summary

Updated PolicyActions.tsx with Follow/Unfollow functionality

# Checklist

- [ ]  When the current user is not already following the relevant bill, the "Follow" button on the Testimony Detail page should read "Follow [Bill]" and clicking it should successfully follow the bill
- [ ] When the current user is already following the relevant bill, the "Follow" button on the Testimony Detail page should read "Unfollow [Bill]" and clicking it should successfully unfolllow the bill

# Screenshots

_Add some screenshots highlighting your changes._

# Known issues

_If you've run against limitations or caveats, include them here. Include follow-up issues as well._

# Steps to test/reproduce

_For each feature or bug fix, create a step by step list for how a reviewer can test it out. E.g.:_

1. Go to the home page
1. Click on a testimony
1. See that it's loaded with a loading spinner
