### PR TITLE
Update Firestore Indexes to include topicName for NotificationEvents

### DIFF
--- a/components/Newsfeed/NotificationProps.tsx
+++ b/components/Newsfeed/NotificationProps.tsx
@@ -4,7 +4,7 @@ export type NotificationProps = {
   bodyText: string
   court: string
   delivered: boolean
-  header: string
+  header: string // Bill Title
   id: number
   subheader: string
   type: string
@@ -12,9 +12,11 @@ export type NotificationProps = {
   timestamp: Timestamp
   createdAt: Timestamp
   position?: string
-  isBillMatch: boolean
-  isUserMatch: boolean
-  authorUid?: string
+  isBillMatch: boolean // Is subscribed to Bill
+  isUserMatch: boolean // is subscribed to User/Org
+  authorUid?: string // Testimony author
+  testimonyId?: string
+  userRole?: string
 }
 
 export type Notifications = NotificationProps[]

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -767,14 +767,25 @@
       "indexes": [{ "queryScope": "COLLECTION_GROUP", "order": "ASCENDING" }]
     },
     {
+      "collectionGroup": "publishedTestimony",
+      "fieldPath": "authorUid",
+      "indexes": [{ "queryScope": "COLLECTION_GROUP", "order": "ASCENDING" }]
+    },
+    //// notifications ////
+    {
       "collectionGroup": "activeTopicSubscriptions",
       "fieldPath": "nextDigestAt",
       "indexes": [{ "queryScope": "COLLECTION_GROUP", "order": "ASCENDING" }]
     },
     {
-      "collectionGroup": "publishedTestimony",
-      "fieldPath": "authorUid",
-      "indexes": [{ "queryScope": "COLLECTION_GROUP", "order": "ASCENDING" }]
+      "collectionGroup": "activeTopicSubscriptions",
+      "fieldPath": "topicName",
+      "indexes": [
+        { "queryScope": "COLLECTION_GROUP", "order": "ASCENDING" },
+        { "queryScope": "COLLECTION", "order": "ASCENDING" },
+        { "queryScope": "COLLECTION", "order": "DESCENDING" },
+        { "queryScope": "COLLECTION", "arrayConfig": "CONTAINS" }
+      ]
     }
   ]
 }

--- a/functions/src/notifications/populateTestimonySubmissionNotificationEvents.ts
+++ b/functions/src/notifications/populateTestimonySubmissionNotificationEvents.ts
@@ -38,6 +38,8 @@ export const populateTestimonySubmissionNotificationEvents = functions.firestore
         billName: newData?.billTitle,
 
         userId: newData?.authorUid,
+        userRole: newData?.authorRole,
+        testimonyId: context.params.testimonyId,
         testimonyUser: newData?.fullName,
         testimonyPosition: newData?.position,
         testimonyContent: newData?.content,

--- a/functions/src/notifications/publishNotifications.ts
+++ b/functions/src/notifications/publishNotifications.ts
@@ -24,6 +24,8 @@ const createNotificationFields = (
   let subheader: string
   let position: string | undefined
   let authorUid: string | undefined
+  let testimonyId: string | undefined
+  let userRole: string | undefined
 
   switch (entity.type) {
     case "bill":
@@ -41,6 +43,8 @@ const createNotificationFields = (
       subheader = entity.testimonyUser
       position = entity.testimonyPosition
       authorUid = entity.userId
+      testimonyId = entity.testimonyId
+      userRole = entity.userRole
       break
 
     default:
@@ -52,7 +56,7 @@ const createNotificationFields = (
     uid: "",
     notification: {
       bodyText: bodyText,
-      header: entity.billId,
+      header: entity.billName,
       court: entity.billCourt,
       id: entity.billId,
       subheader: subheader,
@@ -62,6 +66,8 @@ const createNotificationFields = (
       isBillMatch: false,
       isUserMatch: false,
       delivered: false,
+      testimonyId: testimonyId,
+      userRole: userRole,
       authorUid: authorUid
     },
     createdAt: Timestamp.now()

--- a/functions/src/notifications/types.ts
+++ b/functions/src/notifications/types.ts
@@ -17,6 +17,8 @@ export type BillHistoryUpdateNotification = Notification & {
 export type TestimonySubmissionNotification = Notification & {
   type: "testimony"
   userId: string
+  userRole: string
+  testimonyId: string
   testimonyUser: string
   testimonyPosition: string
   testimonyContent: string
@@ -37,6 +39,8 @@ export interface NotificationFields {
     isBillMatch: boolean
     isUserMatch: boolean
     delivered: boolean
+    testimonyId?: string
+    userRole?: string
     authorUid?: string
   }
   createdAt: FirebaseFirestore.Timestamp


### PR DESCRIPTION
# Summary

- Added a firebase index override to allow for publishNotifications to send notifications to following users

# Checklist

- [ ] On the frontend, I've made my strings translate-able.
- [ ] If I've added shared components, I've added a storybook story.
- [ ] I've made pages responsive and look good on mobile.

# Screenshots

_Add some screenshots highlighting your changes._

# Known issues

_If you've run against limitations or caveats, include them here. Include follow-up issues as well._

# Steps to test/reproduce

_For each feature or bug fix, create a step by step list for how a reviewer can test it out. E.g.:_

1. Check firestore indexes and see if collection ID activeTopicSubscriptions has fieldpath topicName
