### PR TITLE
Make the Notification types more explicit for Testimony vs Bill History notifications

### DIFF
--- a/components/Newsfeed/Newsfeed.tsx
+++ b/components/Newsfeed/Newsfeed.tsx
@@ -181,14 +181,8 @@ export default function Newsfeed() {
                               header={element.header}
                               subheader={element.subheader}
                               timestamp={element.timestamp}
-                              headerImgSrc={`${
-                                element.type === `bill`
-                                  ? ``
-                                  : `/thumbs-${element.position}.svg`
-                              }`}
-                              headerImgTitle={`${
-                                element.type === `bill` ? "" : element.position
-                              }`}
+                              headerImgSrc={`${`/thumbs-${element.position}.svg`}`}
+                              headerImgTitle={element.position}
                               bodyImgSrc={``}
                               bodyImgAltTxt={``}
                               bodyText={element.bodyText}

--- a/components/Newsfeed/NotificationProps.tsx
+++ b/components/Newsfeed/NotificationProps.tsx
@@ -1,22 +1,39 @@
 import { Timestamp } from "firebase/firestore"
 
-export type NotificationProps = {
+export type NotificationProps = BillHistoryNotification | TestimonyNotification
+
+type BillHistoryNotification = {
+  type: "bill"
   bodyText: string
   court: string
   delivered: boolean
   header: string // Bill Title
   id: number
   subheader: string
-  type: string
   topicName: string
   timestamp: Timestamp
   createdAt: Timestamp
-  position?: string
   isBillMatch: boolean // Is subscribed to Bill
   isUserMatch: boolean // is subscribed to User/Org
-  authorUid?: string // Testimony author
-  testimonyId?: string
-  userRole?: string
+}
+
+interface TestimonyNotification {
+  type: "testimony"
+  bodyText: string
+  court: string
+  delivered: boolean
+  header: string // Bill Title
+  id: number
+  subheader: string
+  topicName: string
+  timestamp: Timestamp
+  createdAt: Timestamp
+  position: string
+  isBillMatch: boolean // Is subscribed to Bill
+  isUserMatch: boolean // is subscribed to User/Org
+  authorUid: string // Testimony author
+  testimonyId: string
+  userRole: string
 }
 
 export type Notifications = NotificationProps[]

--- a/components/Newsfeed/NotificationProps.tsx
+++ b/components/Newsfeed/NotificationProps.tsx
@@ -9,6 +9,7 @@ type BillHistoryNotification = {
   delivered: boolean
   header: string // Bill Title
   id: number
+  billId: string
   subheader: string
   topicName: string
   timestamp: Timestamp
@@ -24,6 +25,7 @@ interface TestimonyNotification {
   delivered: boolean
   header: string // Bill Title
   id: number
+  billId: string
   subheader: string
   topicName: string
   timestamp: Timestamp

--- a/functions/src/firebase.ts
+++ b/functions/src/firebase.ts
@@ -2,6 +2,7 @@ import * as admin from "firebase-admin"
 
 admin.initializeApp()
 export const db = admin.firestore()
+db.settings({ ignoreUndefinedProperties: true })
 export const storage = admin.storage()
 export const auth = admin.auth()
 export { admin }

--- a/functions/src/firebase.ts
+++ b/functions/src/firebase.ts
@@ -2,7 +2,6 @@ import * as admin from "firebase-admin"
 
 admin.initializeApp()
 export const db = admin.firestore()
-db.settings({ ignoreUndefinedProperties: true })
 export const storage = admin.storage()
 export const auth = admin.auth()
 export { admin }

--- a/functions/src/notifications/publishNotifications.ts
+++ b/functions/src/notifications/publishNotifications.ts
@@ -9,8 +9,9 @@ import * as admin from "firebase-admin"
 import { Timestamp } from "../firebase"
 import {
   BillHistoryUpdateNotification,
-  NotificationFields,
-  TestimonySubmissionNotification
+  BillHistoryUpdateNotificationFields,
+  TestimonySubmissionNotification,
+  TestimonySubmissionNotificationFields
 } from "./types"
 import { cloneDeep } from "lodash"
 
@@ -19,58 +20,58 @@ const db = admin.firestore()
 
 const createNotificationFields = (
   entity: BillHistoryUpdateNotification | TestimonySubmissionNotification
-): NotificationFields => {
-  let bodyText: string
-  let subheader: string
-  let position: string | undefined
-  let authorUid: string | undefined
-  let testimonyId: string | undefined
-  let userRole: string | undefined
-
+):
+  | BillHistoryUpdateNotificationFields
+  | TestimonySubmissionNotificationFields => {
   switch (entity.type) {
     case "bill":
       if (entity.billHistory.length < 1) {
         console.log(`Invalid history length: ${entity.billHistory.length}`)
         throw new Error(`Invalid history length: ${entity.billHistory.length}`)
       }
-      let lastHistoryAction = entity.billHistory[entity.billHistory.length - 1]
-      bodyText = `${lastHistoryAction.Action}`
-      subheader = `${lastHistoryAction.Branch}`
-      break
+      const lastHistoryAction =
+        entity.billHistory[entity.billHistory.length - 1]
+      return {
+        uid: "",
+        notification: {
+          header: entity.billName,
+          court: entity.billCourt,
+          billId: entity.billId,
+          bodyText: `${lastHistoryAction.Action}`,
+          subheader: `${lastHistoryAction.Branch}`,
+          timestamp: entity.updateTime,
+          type: "bill",
+          isBillMatch: false,
+          isUserMatch: false,
+          delivered: false
+        },
+        createdAt: Timestamp.now()
+      }
 
     case "testimony":
-      bodyText = entity.testimonyContent
-      subheader = entity.testimonyUser
-      position = entity.testimonyPosition
-      authorUid = entity.userId
-      testimonyId = entity.testimonyId
-      userRole = entity.userRole
-      break
-
+      return {
+        uid: "",
+        notification: {
+          header: entity.billName,
+          court: entity.billCourt,
+          billId: entity.billId,
+          bodyText: entity.testimonyContent,
+          subheader: entity.testimonyUser,
+          timestamp: entity.updateTime,
+          position: entity.testimonyPosition,
+          type: "testimony",
+          isBillMatch: false,
+          isUserMatch: false,
+          delivered: false,
+          authorUid: entity.userId,
+          testimonyId: entity.testimonyId,
+          userRole: entity.userRole
+        },
+        createdAt: Timestamp.now()
+      }
     default:
       console.log(`Invalid entity: ${entity}`)
       throw new Error(`Invalid entity: ${entity}`)
-  }
-
-  return {
-    uid: "",
-    notification: {
-      bodyText: bodyText,
-      header: entity.billName,
-      court: entity.billCourt,
-      id: entity.billId,
-      subheader: subheader,
-      timestamp: entity.updateTime,
-      type: entity.type,
-      position: position,
-      isBillMatch: false,
-      isUserMatch: false,
-      delivered: false,
-      testimonyId: testimonyId,
-      userRole: userRole,
-      authorUid: authorUid
-    },
-    createdAt: Timestamp.now()
   }
 }
 

--- a/functions/src/notifications/types.ts
+++ b/functions/src/notifications/types.ts
@@ -25,23 +25,40 @@ export type TestimonySubmissionNotification = Notification & {
   testimonyVersion: number
 }
 
-export interface NotificationFields {
+export interface TestimonySubmissionNotificationFields {
   uid: string
   notification: {
     bodyText: string
     header: string
     court: string
-    id: string
+    billId: string
     subheader: string
     timestamp: FirebaseFirestore.Timestamp
     type: string
-    position?: string
+    position: string
     isBillMatch: boolean
     isUserMatch: boolean
     delivered: boolean
-    testimonyId?: string
-    userRole?: string
-    authorUid?: string
+    testimonyId: string
+    userRole: string
+    authorUid: string
+  }
+  createdAt: FirebaseFirestore.Timestamp
+}
+
+export interface BillHistoryUpdateNotificationFields {
+  uid: string
+  notification: {
+    bodyText: string
+    header: string
+    court: string
+    billId: string
+    subheader: string
+    timestamp: FirebaseFirestore.Timestamp
+    type: string
+    isBillMatch: boolean
+    isUserMatch: boolean
+    delivered: boolean
   }
   createdAt: FirebaseFirestore.Timestamp
 }


### PR DESCRIPTION
# Summary

- Changed the return type in publishNotifications and specified the types more explicitly in the front-end as well

# Checklist

- [ ] On the frontend, I've made my strings translate-able.
- [ ] If I've added shared components, I've added a storybook story.
- [ ] I've made pages responsive and look good on mobile.

# Screenshots

_Add some screenshots highlighting your changes._

# Known issues

_If you've run against limitations or caveats, include them here. Include follow-up issues as well._

# Steps to test/reproduce

_For each feature or bug fix, create a step by step list for how a reviewer can test it out. E.g.:_

1. Try following bills/orgs and have them post testimony
