### PR TITLE
count fixed

### DIFF
--- a/components/search/testimony/TestimonySearch.tsx
+++ b/components/search/testimony/TestimonySearch.tsx
@@ -101,23 +101,23 @@ const Layout = () => {
 
   const onTabClick = (t: Tab) => {
     setKey(t)
-    setIndexUiState((prevState) => {
-      const validRoles = ["user", "organization", "admin"] 
+    setIndexUiState(prevState => {
+      const validRoles = ["user", "organization", "admin"]
       const role =
         t === "Individuals"
           ? ["user"]
           : t === "Organizations"
           ? ["organization"]
-          : validRoles 
+          : validRoles
       return {
         ...prevState,
         refinementList: {
           ...prevState.refinementList,
-          authorRole: role,
-        },
+          authorRole: role
+        }
       }
     })
-  }  
+  }
 
   const [followStatus, setFollowStatus] = useState<OrgFollowStatus>({})
 

--- a/components/search/testimony/TestimonySearch.tsx
+++ b/components/search/testimony/TestimonySearch.tsx
@@ -101,23 +101,23 @@ const Layout = () => {
 
   const onTabClick = (t: Tab) => {
     setKey(t)
-    setIndexUiState(prevState => {
-      const prevRefinements = prevState.refinementList
+    setIndexUiState((prevState) => {
+      const validRoles = ["user", "organization", "admin"] 
       const role =
         t === "Individuals"
           ? ["user"]
           : t === "Organizations"
           ? ["organization"]
-          : ["user", "organization"]
+          : validRoles 
       return {
         ...prevState,
         refinementList: {
           ...prevState.refinementList,
-          authorRole: role
-        }
+          authorRole: role,
+        },
       }
     })
-  }
+  }  
 
   const [followStatus, setFollowStatus] = useState<OrgFollowStatus>({})
 


### PR DESCRIPTION
# Summary
Description:
Fixed the bug related to inconsistent testimony counts when switching between the "All", "Individuals", and "Organizations" tabs on the Browse Testimony page.
Issue Reference:
This PR fixes the issue where testimony counts changed when switching between tabs. The fix accounts for all roles, including "user", "organization", and "admin", ensuring the correct counts are displayed for all tabs.
Closes #1667 .


# Checklist

- [ done] On the frontend, I've made my strings translate-able.
- [ not relevant to issue ] If I've added shared components, I've added a storybook story.
- [ done ] I've made pages responsive and look good on mobile.


# Screenshots
Before Fix:
No testimony count consistency between tabs.

After Fix:
before changing tabs:
![Screenshot 2025-01-14 185526](https://github.com/user-attachments/assets/ae65a2b2-422f-4d7b-a2aa-62b999481772)

after changing tabs:
![Screenshot 2025-01-14 190106](https://github.com/user-attachments/assets/d9640945-2a48-484b-b235-a23b20e5ef16)


# Known issues
No known issues at this time.

# Steps to test/reproduce
1.Go to the Browse Testimony page.
2.Note the initial result count (before clicking any tabs).
3.Click on the Individuals tab.
4.Click on the All tab again.
5.Observe that the count for the All tab remains consistent, without any discrepancies.
