### PR TITLE
fix: hide follow btn for logged out users bill detail pg

### DIFF
--- a/components/bill/BillDetails.tsx
+++ b/components/bill/BillDetails.tsx
@@ -38,6 +38,7 @@ export const BillDetails = ({ bill }: BillProps) => {
   const flags = useFlags()
 
   const [followStatus, setFollowStatus] = useState<OrgFollowStatus>({})
+  const { user } = useAuth()
 
   return (
     <>
@@ -69,7 +70,7 @@ export const BillDetails = ({ bill }: BillProps) => {
               </Row>
               <Row className="mb-4">
                 <Col xs={12} className="d-flex justify-content-end">
-                  {flags.notifications && <FollowBillButton bill={bill} />}
+                  {flags.notifications && user && <FollowBillButton bill={bill} />}
                 </Col>
               </Row>
             </>
@@ -80,7 +81,7 @@ export const BillDetails = ({ bill }: BillProps) => {
               </Col>
               <Col xs={6} className="d-flex justify-content-end">
                 <Styled>
-                  {flags.notifications && <FollowBillButton bill={bill} />}
+                  {flags.notifications && user && <FollowBillButton bill={bill} />}
                 </Styled>
               </Col>
             </Row>

--- a/components/bill/BillDetails.tsx
+++ b/components/bill/BillDetails.tsx
@@ -70,7 +70,9 @@ export const BillDetails = ({ bill }: BillProps) => {
               </Row>
               <Row className="mb-4">
                 <Col xs={12} className="d-flex justify-content-end">
-                  {flags.notifications && user && <FollowBillButton bill={bill} />}
+                  {flags.notifications && user && (
+                    <FollowBillButton bill={bill} />
+                  )}
                 </Col>
               </Row>
             </>
@@ -81,7 +83,9 @@ export const BillDetails = ({ bill }: BillProps) => {
               </Col>
               <Col xs={6} className="d-flex justify-content-end">
                 <Styled>
-                  {flags.notifications && user && <FollowBillButton bill={bill} />}
+                  {flags.notifications && user && (
+                    <FollowBillButton bill={bill} />
+                  )}
                 </Styled>
               </Col>
             </Row>


### PR DESCRIPTION
# Summary

#1668 Hides the Follow Button on the Bill Details page for the logged out user

# Checklist

# Screenshots

_Add some screenshots highlighting your changes._

# Known issues

_If you've run against limitations or caveats, include them here. Include follow-up issues as well._

# Steps to test/reproduce

1. Log out
2. Go to Bill detail page and notice how the Follow button is not present
