### PR TITLE
Add HierarchicalMenu after InstantSearch initialize

### DIFF
--- a/components/search/HierarchicalMenuWidget.tsx
+++ b/components/search/HierarchicalMenuWidget.tsx
@@ -78,7 +78,10 @@ export const connectMultiselectHierarchicalMenu: MultiselectHierarchicalMenuConn
             const sortByParameter = isParent ? ["name:asc"] : ["count:desc"]
 
             // Trigger a new search to apply the updated facets
-            if (!helper.state.disjunctiveFacets.includes(attribute)) {
+            if (
+              helper.state.disjunctiveFacets.length != 0 &&
+              !helper.state.disjunctiveFacets.includes(attribute)
+            ) {
               helper.setQueryParameter("disjunctiveFacets", [
                 ...helper.state.disjunctiveFacets,
                 attribute
@@ -211,6 +214,7 @@ export const connectMultiselectHierarchicalMenu: MultiselectHierarchicalMenuConn
             }),
             {}
           )
+
           return {
             ...uiState,
             multiselectHierarchicalMenu: {
@@ -334,8 +338,7 @@ const MultiselectHierarchicalMenuItem = ({
     item.name,
     isOpen,
     isSubLevelRefined,
-    refine,
-    onButtonClick
+    refine
   ])
 
   useEffect(() => {

--- a/components/search/bills/BillSearch.tsx
+++ b/components/search/bills/BillSearch.tsx
@@ -33,7 +33,6 @@ const searchClient = new TypesenseInstantSearchAdapter({
 
 const extractLastSegmentOfRefinements = (items: any[]) => {
   return items.map(item => {
-    console.log(item)
     if (item.label != "topics.lvl1") return item
     const newRefinements = item.refinements.map(
       (refinement: { label: string }) => {

--- a/components/search/useRefinements.tsx
+++ b/components/search/useRefinements.tsx
@@ -1,7 +1,4 @@
-import {
-  RefinementList,
-  useInstantSearch
-} from "react-instantsearch"
+import { RefinementList, useInstantSearch } from "react-instantsearch"
 import { faFilter } from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
 import { useCallback, useEffect, useState } from "react"

--- a/components/search/useRefinements.tsx
+++ b/components/search/useRefinements.tsx
@@ -1,6 +1,4 @@
 import {
-  HierarchicalMenu,
-  HierarchicalMenuProps,
   RefinementList,
   useInstantSearch
 } from "react-instantsearch"


### PR DESCRIPTION
**1679 Fix Default Filter on Browse Bills Page**

This PR reintroduces the default filter for the current general court on the Browse Bills page.

**To Reproduce the Issue:**
- Navigate to the 'Browse Bills' page on the development site.
- Notice the absence of the default "193rd (Current)" general court filter.

**Expected Behavior with Fix:**
- The "193rd (Current)" filter is applied by default.
- Search results are around ~8,000 relevant entries.

**Screenshots:**
-Before fix bug
<img width="1438" alt="Screenshot 2025-01-21 at 9 33 42 PM" src="https://github.com/user-attachments/assets/61b786aa-f504-4eaf-990c-ecf1c1df7341" />

-After fix bug
<img width="1415" alt="Screenshot 2025-01-21 at 9 32 49 PM" src="https://github.com/user-attachments/assets/4cd6956e-1d8f-451d-8bfb-e74d00f42edd" />

