### PR TITLE
fix: moving new notification index out of fieldOverrides

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -731,6 +731,20 @@
           "order": "DESCENDING"
         }
       ]
+    },
+    {
+      "collectionGroup": "userNotificationFeed",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "notification.type",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "notification.timestamp",
+          "order": "ASCENDING"
+        }
+      ]
     }
   ],
   "fieldOverrides": [
@@ -785,20 +799,6 @@
         { "queryScope": "COLLECTION", "order": "ASCENDING" },
         { "queryScope": "COLLECTION", "order": "DESCENDING" },
         { "queryScope": "COLLECTION", "arrayConfig": "CONTAINS" }
-      ]
-    },
-    {
-      "collectionGroup": "userNotificationFeed",
-      "queryScope": "COLLECTION",
-      "fields": [
-        {
-          "fieldPath": "notification.type",
-          "order": "ASCENDING"
-        },
-        {
-          "fieldPath": "notification.timestamp",
-          "order": "ASCENDING"
-        }
       ]
     }
   ]


### PR DESCRIPTION
# Summary

Whoops, put the new notifications index in the `fieldOverrides` by mistake and it made the deploy process unhappy (the index itself is currently created and working just fine on dev). 

This would get fixed anyway by the firestore indexes sync PR that's almost ready to go, but I don't want to leave main broken while we wait.

Just going to merge this when the repo checks pass.