### PR TITLE
Reordered and Renamed Bill Search filters

### DIFF
--- a/components/search/bills/BillSearch.tsx
+++ b/components/search/bills/BillSearch.tsx
@@ -6,7 +6,7 @@ import {
   SearchBox,
   useInstantSearch
 } from "react-instantsearch"
-import { currentGeneralCourt, isCurrentCourt } from "functions/src/shared"
+import { currentGeneralCourt } from "functions/src/shared"
 import styled from "styled-components"
 import TypesenseInstantSearchAdapter from "typesense-instantsearch-adapter"
 import { Col, Row } from "../../bootstrap"

--- a/components/search/bills/BillSearch.tsx
+++ b/components/search/bills/BillSearch.tsx
@@ -6,7 +6,7 @@ import {
   SearchBox,
   useInstantSearch
 } from "react-instantsearch"
-import { currentGeneralCourt } from "functions/src/shared"
+import { currentLegislativeSession } from "functions/src/shared"
 import styled from "styled-components"
 import TypesenseInstantSearchAdapter from "typesense-instantsearch-adapter"
 import { Col, Row } from "../../bootstrap"
@@ -16,7 +16,7 @@ import { SearchContainer } from "../SearchContainer"
 import { SearchErrorBoundary } from "../SearchErrorBoundary"
 import { useRouting } from "../useRouting"
 import { BillHit } from "./BillHit"
-import { useBillRefinements, useCourtRefinements } from "./useBillRefinements"
+import { useBillRefinements, useSessionRefinements } from "./useBillRefinements"
 import { useBillHierarchicalMenu } from "./useBillHierarchicalMenu"
 import { SortBy, SortByWithConfigurationItem } from "../SortBy"
 import { getServerConfig } from "../common"
@@ -66,7 +66,14 @@ export const BillSearch = () => {
         indexName={initialSortByValue}
         initialUiState={{
           [initialSortByValue]: {
-            refinementList: { court: [String(currentGeneralCourt)] }
+            refinementList: { court: [String(currentLegislativeSession)] }
+            // `court:` should be `session:` but 404 - Could not find a facet field named `session` in the schema.
+            //
+            // needs adjusting? :
+            // node_modules\typesense-instantsearch-adapter\lib\TypesenseInstantsearchAdapter.js
+            //
+            // see also useBillRefinements.tsx:
+            //   attribute: "court",
           }
         }}
         searchClient={searchClient}
@@ -101,12 +108,10 @@ const useSearchStatus = () => {
 const Layout: FC<
   React.PropsWithChildren<{ items: SortByWithConfigurationItem[] }>
 > = ({ items }) => {
-  const courtRefinements = useCourtRefinements()
+  const sessionRefinements = useSessionRefinements()
   const refinements = useBillRefinements()
   const hierarchicalMenu = useBillHierarchicalMenu()
   const status = useSearchStatus()
-
-  console.log("Refinement Options", refinements.options)
 
   return (
     <SearchContainer>
@@ -115,7 +120,7 @@ const Layout: FC<
       </Row>
       <Row>
         <Col xs={3} lg={3}>
-          {courtRefinements.options}
+          {sessionRefinements.options}
           {hierarchicalMenu.options}
           {refinements.options}
         </Col>
@@ -123,6 +128,7 @@ const Layout: FC<
           <RefinementRow>
             <ResultCount className="flex-grow-1 m-1" />
             <SortBy items={items} />
+            {sessionRefinements.show}
             {hierarchicalMenu.show}
             {refinements.show}
           </RefinementRow>

--- a/components/search/bills/BillSearch.tsx
+++ b/components/search/bills/BillSearch.tsx
@@ -6,7 +6,7 @@ import {
   SearchBox,
   useInstantSearch
 } from "react-instantsearch"
-import { currentLegislativeSession } from "functions/src/shared"
+import { currentGeneralCourt } from "functions/src/shared"
 import styled from "styled-components"
 import TypesenseInstantSearchAdapter from "typesense-instantsearch-adapter"
 import { Col, Row } from "../../bootstrap"
@@ -66,14 +66,7 @@ export const BillSearch = () => {
         indexName={initialSortByValue}
         initialUiState={{
           [initialSortByValue]: {
-            refinementList: { court: [String(currentLegislativeSession)] }
-            // `court:` should be `session:` but 404 - Could not find a facet field named `session` in the schema.
-            //
-            // needs adjusting? :
-            // node_modules\typesense-instantsearch-adapter\lib\TypesenseInstantsearchAdapter.js
-            //
-            // see also useBillRefinements.tsx:
-            //   attribute: "court",
+            refinementList: { court: [String(currentGeneralCourt)] }
           }
         }}
         searchClient={searchClient}

--- a/components/search/bills/BillSearch.tsx
+++ b/components/search/bills/BillSearch.tsx
@@ -6,7 +6,7 @@ import {
   SearchBox,
   useInstantSearch
 } from "react-instantsearch"
-import { currentGeneralCourt } from "functions/src/shared"
+import { currentGeneralCourt, isCurrentCourt } from "functions/src/shared"
 import styled from "styled-components"
 import TypesenseInstantSearchAdapter from "typesense-instantsearch-adapter"
 import { Col, Row } from "../../bootstrap"
@@ -16,7 +16,7 @@ import { SearchContainer } from "../SearchContainer"
 import { SearchErrorBoundary } from "../SearchErrorBoundary"
 import { useRouting } from "../useRouting"
 import { BillHit } from "./BillHit"
-import { useBillRefinements, useCourtRefinements } from "./useBillRefinements"
+import { useBillRefinements } from "./useBillRefinements"
 import { useBillHierarchicalMenu } from "./useBillHierarchicalMenu"
 import { SortBy, SortByWithConfigurationItem } from "../SortBy"
 import { getServerConfig } from "../common"
@@ -101,8 +101,8 @@ const useSearchStatus = () => {
 const Layout: FC<
   React.PropsWithChildren<{ items: SortByWithConfigurationItem[] }>
 > = ({ items }) => {
-  const courtRefinements = useCourtRefinements()
-  const refinements = useBillRefinements()
+  const courtRefinements = useBillRefinements(1)
+  const refinements = useBillRefinements(2)
   const hierarchicalMenu = useBillHierarchicalMenu()
   const status = useSearchStatus()
 

--- a/components/search/bills/BillSearch.tsx
+++ b/components/search/bills/BillSearch.tsx
@@ -16,7 +16,7 @@ import { SearchContainer } from "../SearchContainer"
 import { SearchErrorBoundary } from "../SearchErrorBoundary"
 import { useRouting } from "../useRouting"
 import { BillHit } from "./BillHit"
-import { useBillRefinements, useSessionRefinements } from "./useBillRefinements"
+import { useBillRefinements, useCourtRefinements } from "./useBillRefinements"
 import { useBillHierarchicalMenu } from "./useBillHierarchicalMenu"
 import { SortBy, SortByWithConfigurationItem } from "../SortBy"
 import { getServerConfig } from "../common"
@@ -101,7 +101,7 @@ const useSearchStatus = () => {
 const Layout: FC<
   React.PropsWithChildren<{ items: SortByWithConfigurationItem[] }>
 > = ({ items }) => {
-  const sessionRefinements = useSessionRefinements()
+  const courtRefinements = useCourtRefinements()
   const refinements = useBillRefinements()
   const hierarchicalMenu = useBillHierarchicalMenu()
   const status = useSearchStatus()
@@ -113,7 +113,7 @@ const Layout: FC<
       </Row>
       <Row>
         <Col xs={3} lg={3}>
-          {sessionRefinements.options}
+          {courtRefinements.options}
           {hierarchicalMenu.options}
           {refinements.options}
         </Col>
@@ -121,7 +121,7 @@ const Layout: FC<
           <RefinementRow>
             <ResultCount className="flex-grow-1 m-1" />
             <SortBy items={items} />
-            {sessionRefinements.show}
+            {courtRefinements.show}
             {hierarchicalMenu.show}
             {refinements.show}
           </RefinementRow>

--- a/components/search/bills/BillSearch.tsx
+++ b/components/search/bills/BillSearch.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "next-i18next"
 import {
   CurrentRefinements,
   Hits,
@@ -106,6 +107,8 @@ const Layout: FC<
   const hierarchicalMenu = useBillHierarchicalMenu()
   const status = useSearchStatus()
 
+  const { t } = useTranslation("billSearch")
+
   return (
     <SearchContainer>
       <Row>
@@ -132,9 +135,9 @@ const Layout: FC<
           />
           {status === "empty" ? (
             <NoResults>
-              Your search has yielded zero results!
+              {t("zero_results")}
               <br />
-              <b>Try another search term</b>
+              <b>{t("another_term")}</b>
             </NoResults>
           ) : (
             <Hits hitComponent={BillHit} />

--- a/components/search/bills/BillSearch.tsx
+++ b/components/search/bills/BillSearch.tsx
@@ -16,7 +16,7 @@ import { SearchContainer } from "../SearchContainer"
 import { SearchErrorBoundary } from "../SearchErrorBoundary"
 import { useRouting } from "../useRouting"
 import { BillHit } from "./BillHit"
-import { useBillRefinements } from "./useBillRefinements"
+import { useBillRefinements, useCourtRefinements } from "./useBillRefinements"
 import { useBillHierarchicalMenu } from "./useBillHierarchicalMenu"
 import { SortBy, SortByWithConfigurationItem } from "../SortBy"
 import { getServerConfig } from "../common"
@@ -101,9 +101,12 @@ const useSearchStatus = () => {
 const Layout: FC<
   React.PropsWithChildren<{ items: SortByWithConfigurationItem[] }>
 > = ({ items }) => {
+  const courtRefinements = useCourtRefinements()
   const refinements = useBillRefinements()
   const hierarchicalMenu = useBillHierarchicalMenu()
   const status = useSearchStatus()
+
+  console.log("Refinement Options", refinements.options)
 
   return (
     <SearchContainer>
@@ -112,6 +115,7 @@ const Layout: FC<
       </Row>
       <Row>
         <Col xs={3} lg={3}>
+          {courtRefinements.options}
           {hierarchicalMenu.options}
           {refinements.options}
         </Col>

--- a/components/search/bills/BillSearch.tsx
+++ b/components/search/bills/BillSearch.tsx
@@ -102,8 +102,7 @@ const useSearchStatus = () => {
 const Layout: FC<
   React.PropsWithChildren<{ items: SortByWithConfigurationItem[] }>
 > = ({ items }) => {
-  const courtRefinements = useBillRefinements(1)
-  const refinements = useBillRefinements(2)
+  const refinements = useBillRefinements()
   const hierarchicalMenu = useBillHierarchicalMenu()
   const status = useSearchStatus()
 
@@ -116,7 +115,6 @@ const Layout: FC<
       </Row>
       <Row>
         <Col xs={3} lg={3}>
-          {courtRefinements.options}
           {hierarchicalMenu.options}
           {refinements.options}
         </Col>
@@ -124,7 +122,6 @@ const Layout: FC<
           <RefinementRow>
             <ResultCount className="flex-grow-1 m-1" />
             <SortBy items={items} />
-            {courtRefinements.show}
             {hierarchicalMenu.show}
             {refinements.show}
           </RefinementRow>

--- a/components/search/bills/useBillRefinements.tsx
+++ b/components/search/bills/useBillRefinements.tsx
@@ -3,6 +3,19 @@ import { RefinementListItem } from "instantsearch.js/es/connectors/refinement-li
 import { useCallback } from "react"
 import { useRefinements } from "../useRefinements"
 
+// for legacy code purposes, things like:
+//
+//   `legislative session` and `session`
+//
+// are used by variables that are named things like:
+//
+//   `general court` and `court`
+//
+// see example below:
+//
+//   attribute: "court",
+//   searchablePlaceholder: "Legislative Session",
+
 export const useBillRefinements = (list: Number) => {
   const baseProps = { limit: 500, searchable: true }
   const propsList1 = [

--- a/components/search/bills/useBillRefinements.tsx
+++ b/components/search/bills/useBillRefinements.tsx
@@ -3,9 +3,9 @@ import { RefinementListItem } from "instantsearch.js/es/connectors/refinement-li
 import { useCallback } from "react"
 import { useRefinements } from "../useRefinements"
 
-export const useCourtRefinements = () => {
+export const useBillRefinements = (list: Number) => {
   const baseProps = { limit: 500, searchable: true }
-  const propsList = [
+  const propsList1 = [
     {
       transformItems: useCallback(
         (i: RefinementListItem[]) =>
@@ -18,17 +18,11 @@ export const useCourtRefinements = () => {
         []
       ),
       attribute: "court",
-      searchablePlaceholder: "Legislative Session",
+      searchablePlaceholder: "General Court",
       ...baseProps
     }
   ]
-
-  return useRefinements({ refinementProps: propsList })
-}
-
-export const useBillRefinements = () => {
-  const baseProps = { limit: 500, searchable: true }
-  const propsList = [
+  const propsList2 = [
     {
       attribute: "currentCommittee",
       ...baseProps,
@@ -50,6 +44,13 @@ export const useBillRefinements = () => {
       searchablePlaceholder: "Cosponsor"
     }
   ]
+
+  let propsList = []
+  if (list === 1) {
+    propsList = propsList1
+  } else {
+    propsList = propsList2
+  }
 
   return useRefinements({ refinementProps: propsList })
 }

--- a/components/search/bills/useBillRefinements.tsx
+++ b/components/search/bills/useBillRefinements.tsx
@@ -3,7 +3,7 @@ import { RefinementListItem } from "instantsearch.js/es/connectors/refinement-li
 import { useCallback } from "react"
 import { useRefinements } from "../useRefinements"
 
-export const useSessionRefinements = () => {
+export const useCourtRefinements = () => {
   const baseProps = { limit: 500, searchable: true }
   const propsList = [
     {

--- a/components/search/bills/useBillRefinements.tsx
+++ b/components/search/bills/useBillRefinements.tsx
@@ -1,4 +1,4 @@
-import { legislativeSessions } from "functions/src/shared"
+import { generalCourts } from "functions/src/shared"
 import { RefinementListItem } from "instantsearch.js/es/connectors/refinement-list/connectRefinementList"
 import { useCallback } from "react"
 import { useRefinements } from "../useRefinements"
@@ -12,19 +12,12 @@ export const useSessionRefinements = () => {
           i
             .map(i => ({
               ...i,
-              label: legislativeSessions[i.value as any]?.Name ?? i.label
+              label: generalCourts[i.value as any]?.Name ?? i.label
             }))
             .sort((a, b) => Number(b.value) - Number(a.value)),
         []
       ),
       attribute: "court",
-      // `court` should be `session` but 404 - Could not find a facet field named `session` in the schema.
-      //
-      // needs adjusting? :
-      // node_modules\typesense-instantsearch-adapter\lib\TypesenseInstantsearchAdapter.js
-      //
-      // see also BillSearch.tsx:
-      //   refinementList: { court: [String(currentLegislativeSession)] }
       searchablePlaceholder: "Legislative Session",
       ...baseProps
     }

--- a/components/search/bills/useBillRefinements.tsx
+++ b/components/search/bills/useBillRefinements.tsx
@@ -3,7 +3,7 @@ import { RefinementListItem } from "instantsearch.js/es/connectors/refinement-li
 import { useCallback } from "react"
 import { useRefinements } from "../useRefinements"
 
-export const useBillRefinements = () => {
+export const useCourtRefinements = () => {
   const baseProps = { limit: 500, searchable: true }
   const propsList = [
     {
@@ -18,9 +18,17 @@ export const useBillRefinements = () => {
         []
       ),
       attribute: "court",
-      searchablePlaceholder: "General Court",
+      searchablePlaceholder: "Legislative Session",
       ...baseProps
-    },
+    }
+  ]
+
+  return useRefinements({ refinementProps: propsList })
+}
+
+export const useBillRefinements = () => {
+  const baseProps = { limit: 500, searchable: true }
+  const propsList = [
     {
       attribute: "currentCommittee",
       ...baseProps,

--- a/components/search/bills/useBillRefinements.tsx
+++ b/components/search/bills/useBillRefinements.tsx
@@ -1,9 +1,9 @@
-import { generalCourts } from "functions/src/shared"
+import { legislativeSessions } from "functions/src/shared"
 import { RefinementListItem } from "instantsearch.js/es/connectors/refinement-list/connectRefinementList"
 import { useCallback } from "react"
 import { useRefinements } from "../useRefinements"
 
-export const useCourtRefinements = () => {
+export const useSessionRefinements = () => {
   const baseProps = { limit: 500, searchable: true }
   const propsList = [
     {
@@ -12,12 +12,19 @@ export const useCourtRefinements = () => {
           i
             .map(i => ({
               ...i,
-              label: generalCourts[i.value as any]?.Name ?? i.label
+              label: legislativeSessions[i.value as any]?.Name ?? i.label
             }))
             .sort((a, b) => Number(b.value) - Number(a.value)),
         []
       ),
       attribute: "court",
+      // `court` should be `session` but 404 - Could not find a facet field named `session` in the schema.
+      //
+      // needs adjusting? :
+      // node_modules\typesense-instantsearch-adapter\lib\TypesenseInstantsearchAdapter.js
+      //
+      // see also BillSearch.tsx:
+      //   refinementList: { court: [String(currentLegislativeSession)] }
       searchablePlaceholder: "Legislative Session",
       ...baseProps
     }

--- a/components/search/bills/useBillRefinements.tsx
+++ b/components/search/bills/useBillRefinements.tsx
@@ -16,9 +16,9 @@ import { useRefinements } from "../useRefinements"
 //   attribute: "court",
 //   searchablePlaceholder: "Legislative Session",
 
-export const useBillRefinements = (list: Number) => {
+export const useBillRefinements = () => {
   const baseProps = { limit: 500, searchable: true }
-  const propsList1 = [
+  const propsList = [
     {
       transformItems: useCallback(
         (i: RefinementListItem[]) =>
@@ -33,9 +33,7 @@ export const useBillRefinements = (list: Number) => {
       attribute: "court",
       searchablePlaceholder: "Legislative Session",
       ...baseProps
-    }
-  ]
-  const propsList2 = [
+    },
     {
       attribute: "currentCommittee",
       ...baseProps,
@@ -57,13 +55,6 @@ export const useBillRefinements = (list: Number) => {
       searchablePlaceholder: "Cosponsor"
     }
   ]
-
-  let propsList = []
-  if (list === 1) {
-    propsList = propsList1
-  } else {
-    propsList = propsList2
-  }
 
   return useRefinements({ refinementProps: propsList })
 }

--- a/components/search/bills/useBillRefinements.tsx
+++ b/components/search/bills/useBillRefinements.tsx
@@ -18,7 +18,7 @@ export const useBillRefinements = (list: Number) => {
         []
       ),
       attribute: "court",
-      searchablePlaceholder: "General Court",
+      searchablePlaceholder: "Legislative Session",
       ...baseProps
     }
   ]

--- a/components/search/useHierarchicalMenu.tsx
+++ b/components/search/useHierarchicalMenu.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "next-i18next"
 import { useInstantSearch } from "react-instantsearch"
 import { faFilter } from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
@@ -42,13 +43,15 @@ export const useHierarchicalMenu = ({
   )
   const hasRefinements = useHasRefinements()
 
+  const { t } = useTranslation("billSearch")
+
   return {
     options: inline ? (
       <div>{hierarchicalMenu}</div>
     ) : (
       <Offcanvas show={show} onHide={handleClose}>
         <Offcanvas.Header closeButton>
-          <Offcanvas.Title>Filter</Offcanvas.Title>
+          <Offcanvas.Title>{t("topics")}</Offcanvas.Title>
         </Offcanvas.Header>
         <Offcanvas.Body>
           <SearchContainer>{hierarchicalMenu}</SearchContainer>
@@ -62,7 +65,7 @@ export const useHierarchicalMenu = ({
         onClick={handleOpen}
         className={hasRefinements ? "ais-FilterButton-has-refinements" : ""}
       >
-        <FontAwesomeIcon icon={faFilter} /> Filter
+        <FontAwesomeIcon icon={faFilter} /> {t("topics")}
       </FilterButton>
     )
   }

--- a/components/search/useRefinements.tsx
+++ b/components/search/useRefinements.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "next-i18next"
 import { RefinementList, useInstantSearch } from "react-instantsearch"
 import { faFilter } from "@fortawesome/free-solid-svg-icons"
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
@@ -39,13 +40,15 @@ export const useRefinements = ({
   )
   const hasRefinements = useHasRefinements()
 
+  const { t } = useTranslation("billSearch")
+
   return {
     options: inline ? (
       <div>{refinements}</div>
     ) : (
       <Offcanvas show={show} onHide={handleClose}>
         <Offcanvas.Header closeButton>
-          <Offcanvas.Title>Filter</Offcanvas.Title>
+          <Offcanvas.Title>{t("filter")}</Offcanvas.Title>
         </Offcanvas.Header>
         <Offcanvas.Body>
           <SearchContainer>{refinements}</SearchContainer>
@@ -59,7 +62,7 @@ export const useRefinements = ({
         onClick={handleOpen}
         className={hasRefinements ? "ais-FilterButton-has-refinements" : ""}
       >
-        <FontAwesomeIcon icon={faFilter} /> Filter
+        <FontAwesomeIcon icon={faFilter} /> {t("filter")}
       </FilterButton>
     )
   }

--- a/functions/src/shared/constants.ts
+++ b/functions/src/shared/constants.ts
@@ -1,11 +1,14 @@
-export type GeneralCourt = {
+export type LegislativeSession = {
   Name: string
   Number: number
   FirstYear: number
   SecondYear: number
 }
 
-export const generalCourts: Record<number, GeneralCourt | undefined> = {
+export const legislativeSessions: Record<
+  number,
+  LegislativeSession | undefined
+> = {
   194: {
     Name: "194th (Current)",
     Number: 194,
@@ -26,12 +29,12 @@ export const generalCourts: Record<number, GeneralCourt | undefined> = {
   }
 }
 
-export const supportedGeneralCourts = Object.keys(generalCourts)
+export const supportedLegislativeSessions = Object.keys(legislativeSessions)
   .map(n => Number.parseInt(n))
   .sort()
   .reverse()
 
-export const currentGeneralCourt = supportedGeneralCourts[0]
+export const currentLegislativeSession = supportedLegislativeSessions[0]
 
-export const isCurrentCourt = (courtNumber: number) =>
-  courtNumber === currentGeneralCourt
+export const isCurrentSession = (courtSession: number) =>
+  courtSession === currentLegislativeSession

--- a/functions/src/shared/constants.ts
+++ b/functions/src/shared/constants.ts
@@ -33,5 +33,5 @@ export const supportedGeneralCourts = Object.keys(generalCourts)
 
 export const currentGeneralCourt = supportedGeneralCourts[0]
 
-export const isCurrentCourt = (courtSession: number) =>
-  courtSession === currentGeneralCourt
+export const isCurrentCourt = (courtNumber: number) =>
+  courtNumber === currentGeneralCourt

--- a/functions/src/shared/constants.ts
+++ b/functions/src/shared/constants.ts
@@ -1,14 +1,11 @@
-export type LegislativeSession = {
+export type GeneralCourt = {
   Name: string
   Number: number
   FirstYear: number
   SecondYear: number
 }
 
-export const legislativeSessions: Record<
-  number,
-  LegislativeSession | undefined
-> = {
+export const generalCourts: Record<number, GeneralCourt | undefined> = {
   194: {
     Name: "194th (Current)",
     Number: 194,
@@ -29,12 +26,12 @@ export const legislativeSessions: Record<
   }
 }
 
-export const supportedLegislativeSessions = Object.keys(legislativeSessions)
+export const supportedGeneralCourts = Object.keys(generalCourts)
   .map(n => Number.parseInt(n))
   .sort()
   .reverse()
 
-export const currentLegislativeSession = supportedLegislativeSessions[0]
+export const currentGeneralCourt = supportedGeneralCourts[0]
 
-export const isCurrentSession = (courtSession: number) =>
-  courtSession === currentLegislativeSession
+export const isCurrentCourt = (courtSession: number) =>
+  courtSession === currentGeneralCourt

--- a/pages/bills/index.tsx
+++ b/pages/bills/index.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from "next-i18next"
 import { Container } from "components/bootstrap"
 import { createPage } from "components/page"
 import { BillSearch } from "components/search"
@@ -6,9 +7,11 @@ import { createGetStaticTranslationProps } from "components/translations"
 export default createPage({
   title: "Browse Bills",
   Page: () => {
+    const { t } = useTranslation("billSearch")
+
     return (
       <Container fluid="md" className="mt-3">
-        <h1>Browse Bills</h1>
+        <h1>{t("browse_bills")}</h1>
         <BillSearch />
       </Container>
     )
@@ -17,6 +20,7 @@ export default createPage({
 
 export const getStaticProps = createGetStaticTranslationProps([
   "auth",
+  "billSearch",
   "common",
   "footer",
   "testimony"

--- a/public/locales/en/billSearch.json
+++ b/public/locales/en/billSearch.json
@@ -1,0 +1,5 @@
+{
+  "another_term" : "Try another search term",
+  "browse_bills" : "Browse Bills",
+  "zero_results" : "Your search has yielded zero results!"
+}

--- a/public/locales/en/billSearch.json
+++ b/public/locales/en/billSearch.json
@@ -1,5 +1,7 @@
 {
   "another_term" : "Try another search term",
   "browse_bills" : "Browse Bills",
+  "filter" : "Filter",
+  "topics" : "Topics",
   "zero_results" : "Your search has yielded zero results!"
 }


### PR DESCRIPTION
# Summary

#1727 

~~reordered and~~ renamed filters per issue

![bug](https://github.com/user-attachments/assets/15c113a3-4dbc-4406-b182-dde480846e77)

# Checklist

- [x] On the frontend, I've made my strings translate-able.
- [n/a] If I've added shared components, I've added a storybook story.
- [n/a ] I've made pages responsive and look good on mobile.

# Screenshots

Previous Display:

![image](https://github.com/user-attachments/assets/62ced620-9fa0-48b6-9d79-36874bd748e0)

Filters ~~Reordered and~~ Renamed:

![image](https://github.com/user-attachments/assets/421c8f1e-8317-4b5d-9624-cc282326e943)

# By Abandoning the Reordering, the Known Issues are simply for Archival Purposes

# ~~Known issues 1~~

1) unable to set default session filter to the current session:

This order (courtRefinements over heirarchialMenu) breaks default (`194th current` prechecked on page load)

```
<SearchContainer>
      <Row>
        <SearchBox placeholder="Search For Bills" className="mt-2 mb-3" />
      </Row>
      <Row>
        <Col xs={3} lg={3}>
          {courtRefinements.options}
          {hierarchicalMenu.options}
          {refinements.options}
        </Col>
```

but if you switch the order of {courtRefinements.options} and {hierarchicalMenu.options}

```
        <Col xs={3} lg={3}>
          {hierarchicalMenu.options}
          {courtRefinements.options}
          {refinements.options}
        </Col>
```

then the default works but you lose the requested reordering

# ~~Known issues 2~~

when court/session filter is set to `194th (Current)` only, the Topics Filter becomes unuable

~~the loss of functionality is puzzling but possibly intentional~~

it is intentional, the Topics filter controls the Court filter

i.e. 
if, under Topics, you check Commerce > Consumer Protection,
then the Court filter is restricted to `193rd (2023-2024)`

see: Known issues 3

# ~~Known issues 3~~

upon addition testing the Topics (read as hierarchicalMenu in the code) *controls* the Legislative Session (courts) filter

it seems that moving the Topics Menu under the Session Menu that it controls:

on the one hand

1) does not cause a hard break of functionality

however

2) does give the user a potentional jarring experience as the user going from top to bottom, first selects one filter, then selects the next only to have the first filter reconfigure itself

Conclusion: I personally do not recommend reordering the filters, but either order is technically feasable

Recommend seeking addional data points/opinions from a wider pool of users than just myself

# Steps to test/reproduce

1. Go to Browse Bills page
2. play with filters

