### PR TITLE
Fix default court filter on Browse bills page

### DIFF
--- a/components/search/HierarchicalMenuWidget.tsx
+++ b/components/search/HierarchicalMenuWidget.tsx
@@ -77,18 +77,6 @@ export const connectMultiselectHierarchicalMenu: MultiselectHierarchicalMenuConn
           ): MultiselectHierarchicalMenuItem[] => {
             const sortByParameter = isParent ? ["name:asc"] : ["count:desc"]
 
-            // Trigger a new search to apply the updated facets
-            if (
-              helper.state.disjunctiveFacets.length != 0 &&
-              !helper.state.disjunctiveFacets.includes(attribute)
-            ) {
-              helper.setQueryParameter("disjunctiveFacets", [
-                ...helper.state.disjunctiveFacets,
-                attribute
-              ])
-              helper.search()
-            }
-
             const facetValues =
               (results?.getFacetValues(attribute, {
                 sortBy: sortByParameter
@@ -151,7 +139,6 @@ export const connectMultiselectHierarchicalMenu: MultiselectHierarchicalMenuConn
                 } else {
                   helper.removeDisjunctiveFacetRefinement(attribute, value)
                 }
-
                 helper.search()
               }
 
@@ -182,7 +169,17 @@ export const connectMultiselectHierarchicalMenu: MultiselectHierarchicalMenuConn
           }
         },
         init(initOptions) {
-          const { instantSearchInstance } = initOptions
+          const { helper, instantSearchInstance } = initOptions
+          attributes.forEach(attr => {
+            if (!helper.state.disjunctiveFacets.includes(attr)) {
+              helper.setQueryParameter("disjunctiveFacets", [
+                ...helper.state.disjunctiveFacets,
+                attr
+              ])
+            }
+          })
+          helper.search()
+
           renderFn(
             {
               ...this.getWidgetRenderState(initOptions),


### PR DESCRIPTION
# Summary

Move the attributes registration from getItems to init since it will overwrite the default filter we have.

# Checklist

- [ ] If the default 194 court filter is applied for both mobile and desktop. 

# Steps to test/reproduce

1. Go to the browse bills page
2. See if the court filter applied
3. resize window to mobile size to see if it still applied.
