### PR TITLE
Fix the HierarchicalMenu clean refinement logic

### DIFF
--- a/components/search/HierarchicalMenuWidget.tsx
+++ b/components/search/HierarchicalMenuWidget.tsx
@@ -312,14 +312,18 @@ const MultiselectHierarchicalMenuItem = ({
 
   const onButtonClick = useCallback(() => {
     if (isOpen) {
-      // Clear all refinements
-      levels.forEach(level => {
-        level.items.forEach(subItem => {
-          if (subItem.isRefined) {
-            level.refine(subItem.name)
-          }
-        })
-      })
+      const currentLevel = levels[index]
+      const subLevel = levels[index + 1]
+      if (item.isRefined) {
+        currentLevel.refine(item.name)
+      }
+      if (subLevel) {
+        subLevel.items
+          .filter(
+            subItem => subItem.name.startsWith(item.name) && subItem.isRefined
+          )
+          .forEach(subItem => subLevel.refine(subItem.name))
+      }
     }
     setIsOpen(!isOpen)
   }, [isOpen, levels])


### PR DESCRIPTION
# Summary

Originally if you close one of the category it will clear all the filter from HierarchicalMenu, no it will only clear that specific category.

# Checklist

- [ ] If the HierarchicalMenu only clear the category we close.


# Steps to test/reproduce

1. Go to the Browse bill page
1. Click at least two categories of HierarchicalMenu
1. Close any of them to see if the other filter still applied 
