### PR TITLE
Fix Tag Filters on Mobile View

### DIFF
--- a/components/search/common.tsx
+++ b/components/search/common.tsx
@@ -30,7 +30,7 @@ export function getServerConfig(): TypesenseInstantsearchAdapterOptions["server"
 }
 
 function RefinementList({ attribute }: { attribute: string }) {
-  useRefinementList({ attribute })
+  useRefinementList({ attribute, limit: 500 })
   return null
 }
 
@@ -39,13 +39,13 @@ export function VirtualFilters({ type }: { type: "bill" | "testimony" }) {
     type === "testimony"
       ? ["authorDisplayName", "court", "position", "billId", "authorRole"]
       : [
-          "court",
-          "currentCommittee",
-          "city",
-          "primarySponsor",
-          "cosponsors",
-          "topics.lvl1"
-        ]
+        "court",
+        "currentCommittee",
+        "city",
+        "primarySponsor",
+        "cosponsors",
+        "topics.lvl1"
+      ]
 
   return (
     <>

--- a/components/search/common.tsx
+++ b/components/search/common.tsx
@@ -39,13 +39,13 @@ export function VirtualFilters({ type }: { type: "bill" | "testimony" }) {
     type === "testimony"
       ? ["authorDisplayName", "court", "position", "billId", "authorRole"]
       : [
-        "court",
-        "currentCommittee",
-        "city",
-        "primarySponsor",
-        "cosponsors",
-        "topics.lvl1"
-      ]
+          "court",
+          "currentCommittee",
+          "city",
+          "primarySponsor",
+          "cosponsors",
+          "topics.lvl1"
+        ]
 
   return (
     <>


### PR DESCRIPTION
# Summary

- Increased the limit of the tags RefinementList to allow all the tags to populate

# Checklist

- [x] On the frontend, I've made my strings translate-able.
- [ ] If I've added shared components, I've added a storybook story.
- [ ] I've made pages responsive and look good on mobile.

# Screenshots


# Known issues

- One thing to note is that selecting too many tags will stretch the screen, but that should be covered in a different ticket

# Steps to test/reproduce

_For each feature or bug fix, create a step by step list for how a reviewer can test it out. E.g.:_

1. Go to Bill Search in mobile view
2. Select multiple tags and see if the view/selection stays the same without bugging out
3. Close filters to see if the tags persist
