### PR TITLE
Update profile creation to set Profile all at once at the beginning of the process

### DIFF
--- a/components/auth/hooks.ts
+++ b/components/auth/hooks.ts
@@ -67,31 +67,24 @@ export function useCreateUserWithEmailAndPassword(isOrg: boolean) {
         email,
         password
       )
-      await finishSignup({ requestedRole: isOrg ? "organization" : "user" })
-
-      const categories = orgCategory ? [orgCategory] : ""
-
       if (isOrg) {
-        await Promise.all([
-          setProfile(credentials.user.uid, {
-            fullName,
-            orgCategories: categories,
-            notificationFrequency: "Monthly",
-            email: credentials.user.email
-          }),
-          sendEmailVerification(credentials.user)
-        ])
+        await finishSignup({
+          requestedRole: "organization",
+          fullName,
+          orgCategories: orgCategory ? [orgCategory] : "",
+          notificationFrequency: "Monthly",
+          email: credentials.user.email
+        })
       } else {
-        await Promise.all([
-          setProfile(credentials.user.uid, {
-            fullName,
-            notificationFrequency: "Monthly",
-            email: credentials.user.email,
-            public: true
-          }),
-          sendEmailVerification(credentials.user)
-        ])
+        await finishSignup({
+          requestedRole: "user",
+          fullName,
+          notificationFrequency: "Monthly",
+          email: credentials.user.email,
+          public: true
+        })
       }
+      await sendEmailVerification(credentials.user)
 
       return credentials
     }

--- a/components/auth/types.tsx
+++ b/components/auth/types.tsx
@@ -1,10 +1,11 @@
 import { functions } from "components/firebase"
 import { httpsCallable } from "firebase/functions"
 import { Role } from "../../functions/src/auth/types"
+import { Profile } from "components/db"
 
 export * from "../../functions/src/auth/types"
 
-export const finishSignup = httpsCallable<{ requestedRole: Role }, void>(
-  functions,
-  "finishSignup"
-)
+export const finishSignup = httpsCallable<
+  { requestedRole: Role } | Partial<Profile>,
+  void
+>(functions, "finishSignup")

--- a/functions/src/auth/setRole.ts
+++ b/functions/src/auth/setRole.ts
@@ -9,13 +9,15 @@ export const setRole = async ({
   uid,
   role,
   auth,
-  db
+  db,
+  newProfile
 }: {
   email?: string
   uid?: string
   role: Role
   auth: Auth
   db: Database
+  newProfile?: Partial<Profile>
 }) => {
   let user: UserRecord
   if (email) user = await auth.getUserByEmail(email)
@@ -30,7 +32,8 @@ export const setRole = async ({
   const currentProfile = Profile.Or(Undefined).check(profileData)
   const profileUpdate: Partial<Profile> = {
     role,
-    public: isPublic(currentProfile, role)
+    public: isPublic(currentProfile, role),
+    ...newProfile
   }
   await profile.set(profileUpdate, { merge: true })
 

--- a/functions/src/profile/finishSignup.ts
+++ b/functions/src/profile/finishSignup.ts
@@ -3,7 +3,6 @@ import { db, auth } from "../firebase"
 import { z } from "zod"
 import { checkRequestZod, checkAuth } from "../common"
 import { setRole } from "../auth"
-import { Role } from "../auth/types"
 
 const CreateProfileRequest = z.object({
   requestedRole: z.enum(["user", "organization", "pendingUpgrade"])
@@ -14,21 +13,31 @@ export const finishSignup = functions.https.onCall(async (data, context) => {
 
   const { requestedRole } = checkRequestZod(CreateProfileRequest, data)
 
-  let role: Role = "user"
+  const {
+    fullName,
+    orgCategories,
+    notificationFrequency,
+    email,
+    public: isPublic
+  } = data
 
   // Only an admin can approve organizations, after they've signed up initially
   // There's a nextjs api route: PATCH /users/<uid> {"role": <role>}
   if (requestedRole === "organization") {
-    role = "pendingUpgrade"
+    await setRole({
+      role: "pendingUpgrade",
+      auth,
+      db,
+      uid,
+      newProfile: { fullName, email, orgCategories }
+    })
+  } else {
+    await setRole({
+      role: "user",
+      auth,
+      db,
+      uid,
+      newProfile: { fullName, notificationFrequency, email, public: isPublic }
+    })
   }
-
-  await setRole({ role, auth, db, uid })
-
-  // upgrade requests table pulls from the profiles collection
-  await db.doc(`profiles/${uid}`).set(
-    {
-      role
-    },
-    { merge: true }
-  )
 })

--- a/functions/src/profile/types.ts
+++ b/functions/src/profile/types.ts
@@ -26,6 +26,14 @@ export const Profile = Record({
   about: Optional(String),
   social: Optional(Dictionary(String)),
   organization: Optional(Boolean),
-  orgCategories: Optional(Array(String.Or(Null)))
+  orgCategories: Optional(Array(String.Or(Null))),
+  email: Optional(String.Or(Null)),
+  notificationFrequency: Optional(String),
+  nextDigestAt: Optional(String),
+  profileImage: Optional(String),
+  billsFollowing: Optional(Array(String)),
+  contactInfo: Optional(Dictionary(String)),
+  location: Optional(String)
 })
+
 export type Profile = Static<typeof Profile>


### PR DESCRIPTION
# Summary

To help #1768 work properly
- Moves all the profile setting calls to one place so that onCreate, the code will have all the details it needs to populate the email.
- Tested with the new functions in place, and the emails are populating the details correctly.

# Checklist

- [ ] On the frontend, I've made my strings translate-able.
- [ ] If I've added shared components, I've added a storybook story.
- [ ] I've made pages responsive and look good on mobile.

# Screenshots

# Known issues
- Don't know if this might break with the current firebase objects, so we'll have to see

# Steps to test/reproduce

1. Create an organization profile
2. See if the data is populated correctly.
