### PR TITLE
Add user privacy check to hide FollowUserButton for private users

### DIFF
--- a/components/search/testimony/TestimonyHit.tsx
+++ b/components/search/testimony/TestimonyHit.tsx
@@ -71,7 +71,7 @@ const TestimonyResult = ({ hit }: { hit: Hit<Testimony> }) => {
         <span style={{ flexGrow: 1 }}>
           <b>Written by {writtenBy}</b>
         </span>
-        {!isCurrentUser && followOrg && user && (
+        {hit.public && !isCurrentUser && followOrg && user && (
           <FollowUserButton profileId={hit.authorUid} />
         )}
       </div>


### PR DESCRIPTION
# Summary

This PR adds a  user privacy check to the TestimonyHit component to hide the FollowUserButton for private users.

# Checklist

- [x] On the frontend, I've made my strings translate-able.
- [ ] If I've added shared components, I've added a storybook story.
- [ ] I've made pages responsive and look good on mobile.

# Screenshots
<img width="1033" alt="Screenshot 2025-05-14 at 8 36 17 AM" src="https://github.com/user-attachments/assets/c64c9c09-affa-406b-a508-26a1ac3c6d38" />


# Known issues

The hit.public field is assumed to be available in the search index.

# Steps to test/reproduce

1. Go to the home page
2. Logged in as a user who can follow others.
1. Go to the browse testimony page
1. Confirm that the Following Button is displayed for that private user.
