### PR TITLE
1795 auth redirect newsfeed

### DIFF
--- a/components/Newsfeed/Newsfeed.tsx
+++ b/components/Newsfeed/Newsfeed.tsx
@@ -7,6 +7,7 @@ import { Col, Row, Spinner } from "../bootstrap"
 import { Profile, useProfile, usePublicProfile } from "../db"
 import { NotificationProps, Notifications } from "./NotificationProps"
 import notificationQuery from "./notification-query"
+
 import {
   BillCol,
   Header,
@@ -16,6 +17,8 @@ import {
 import ProfileSettingsModal from "components/EditProfilePage/ProfileSettingsModal"
 import { NewsfeedCard } from "components/NewsfeedCard/NewsfeedCard"
 import { ProfileButtons } from "components/ProfilePage/ProfileButtons"
+import { useAppDispatch } from "components/hooks"
+import { authStepChanged } from "components/auth/redux"
 
 export default function Newsfeed() {
   const { t } = useTranslation("common")
@@ -30,6 +33,26 @@ export default function Newsfeed() {
 
   const [allResults, setAllResults] = useState<Notifications>([])
   const [filteredResults, setFilteredResults] = useState<Notifications>([])
+
+  const dispatch = useAppDispatch()
+
+  const [initialLoadComplete, setInitialLoadComplete] = useState(false)
+
+  useEffect(() => {
+    if (!loading) {
+      setInitialLoadComplete(true)
+    }
+  }, [loading])
+
+  useEffect(() => {
+    if (!initialLoadComplete) return
+
+    if (!profile) {
+      dispatch(authStepChanged("protectedpage"))
+    } else {
+      dispatch(authStepChanged(null))
+    }
+  }, [dispatch, profile, initialLoadComplete])
 
   useEffect(() => {
     const results = allResults.filter(result => {
@@ -251,7 +274,7 @@ export default function Newsfeed() {
               </StyledContainer>
             </div>
           ) : (
-            <ErrorPage statusCode={404} withDarkMode={false} />
+            <ErrorPage statusCode={401} withDarkMode={false} />
           )}
         </>
       )}

--- a/components/auth/AuthModal.tsx
+++ b/components/auth/AuthModal.tsx
@@ -7,14 +7,20 @@ import VerifyEmailModal from "./VerifyEmailModal"
 import ProfileTypeModal from "./ProfileTypeModal"
 import { AuthFlowStep, authStepChanged, useAuth } from "./redux"
 import { useAppDispatch } from "components/hooks"
+import ProtectedPageAuthModal from "./ProtectedPageAuthModal"
+import { useRouter } from "next/router"
 
 export default function AuthModal() {
   const dispatch = useAppDispatch()
+  const router = useRouter()
   const { authFlowStep: currentModal } = useAuth()
   const setCurrentModal = (step: AuthFlowStep) =>
     dispatch(authStepChanged(step))
   const close = () => dispatch(authStepChanged(null))
-
+  const closeAndRedirectHome = () => {
+    dispatch(authStepChanged(null))
+    router.push("/")
+  }
   return (
     <>
       <StartModal
@@ -48,6 +54,13 @@ export default function AuthModal() {
       <ForgotPasswordModal
         show={currentModal === "forgotPassword"}
         onHide={() => setCurrentModal("signIn")}
+      />
+
+      <ProtectedPageAuthModal
+        show={currentModal === "protectedpage"}
+        onHide={closeAndRedirectHome}
+        onSignInClick={() => setCurrentModal("signIn")}
+        onSignUpClick={() => setCurrentModal("chooseProfileType")}
       />
     </>
   )

--- a/components/auth/ProtectedPageAuthModal.tsx
+++ b/components/auth/ProtectedPageAuthModal.tsx
@@ -1,0 +1,41 @@
+import type { ModalProps } from "react-bootstrap"
+import { Button, Col, Image, Modal, Stack } from "../bootstrap"
+import { useTranslation } from "next-i18next"
+
+export default function ProtectedPageAuthModal({
+  show,
+  onHide,
+  onSignInClick,
+  onSignUpClick
+}: Pick<ModalProps, "show" | "onHide"> & {
+  onSignInClick: () => void
+  onSignUpClick: () => void
+}) {
+  const { t } = useTranslation("auth")
+
+  return (
+    <Modal show={show} onHide={onHide} aria-labelledby="start-modal" centered>
+      <Modal.Header closeButton className={`py-4`}>
+        <Modal.Title id="start-modal" className="visually-hidden">
+          {t("signUpOrIn")}
+        </Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <Col md={7} className="mx-auto">
+          <Stack gap={3} direction="vertical" className="mb-4 text-center">
+            <Image fluid src="/gov-with-mics.svg" alt="" />
+
+            <p className="h5">{t("loginForProtectedAccess")}</p>
+          </Stack>
+
+          <Stack gap={3}>
+            <Button onClick={onSignUpClick}>{t("signUp")}</Button>
+            <Button variant="outline-primary" onClick={onSignInClick}>
+              {t("signIn")}
+            </Button>
+          </Stack>
+        </Col>
+      </Modal.Body>
+    </Modal>
+  )
+}

--- a/components/auth/redux.ts
+++ b/components/auth/redux.ts
@@ -12,6 +12,7 @@ export type AuthFlowStep =
   | "forgotPassword"
   | "verifyEmail"
   | "chooseProfileType"
+  | "protectedpage"
   | null
 
 export interface State {

--- a/public/locales/en/auth.json
+++ b/public/locales/en/auth.json
@@ -54,7 +54,6 @@
   "subscribeNewsletter": "Click here to subscribe to our newsletter",
   "verifyEmail": "Verify your email address",
   "verifyLinkSent": "Please verify your email for your account by clicking the verification link we sent to your email. You will be required to verify your email before submitting testimony.",
-  "setUpProfile": "Set Up Your Profile"
-  
-
+  "setUpProfile": "Set Up Your Profile",
+  "loginForProtectedAccess": "Please log in to access this protected page"
 }


### PR DESCRIPTION
# Summary

This PR implements a pop-up modal for logged-out users attempting to access auth-required pages(newsfeed page). After successful authentication, users are redirected back to the originally requested page.If the user closes the modal, they are redirected to the homepage.

# Checklist

- [x] On the frontend, I've made my strings translate-able.
- [ ] If I've added shared components, I've added a storybook story.
- [x] I've made pages responsive and look good on mobile.

# Screenshots

Login/Signup Modal for Logged-Out Users
<img width="1440" alt="Screenshot 2025-06-11 at 8 13 55 AM" src="https://github.com/user-attachments/assets/4ef2da5d-94ad-4216-99d4-9b643f837f35" />


# Known issues

- On authorized(log in) newsfeed page, there’s a brief flash of the modal if refresh the page. 

- When user log out on newsfeed page will redirect to homepage and modal will also be triggered.

# Steps to test/reproduce

_For each feature or bug fix, create a step by step list for how a reviewer can test it out. E.g.:_

1. Ensure you are logged out.
2. Go to the newsfeed page (/newsfeed).
3. Refresh the page and confirm the modal remains open (does not close).
4. Close the modal (e.g., click the close button) and verify redirection to the homepage (/).
5. Go back to the newsfeed page (/newsfeed).
6. Finish login flow.
7. Confirm that after authentication, the modal closes, and you are redirected to the newsfeed page.
8. Log out and check that you are redirected to the homepage with the modal on.
