### PR TITLE
fix(auth): unify modal logic for all protected pages and improve logi…

### DIFF
--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -4,6 +4,7 @@ import { authStepChanged } from "components/auth/redux"
 import { useAppDispatch } from "components/hooks"
 import { User } from "firebase/auth"
 import { useTranslation } from "next-i18next"
+import { useEffect, useRef } from "react"
 import styled from "styled-components"
 import { NavLink } from "../Navlink"
 import { Button, Col, Image, Container, Row, Nav, Navbar } from "../bootstrap"
@@ -145,6 +146,37 @@ const TermsAndPolicies = () => {
 const AccountLinks = ({ authenticated, user, signOut }: PageFooterProps) => {
   const dispatch = useAppDispatch()
   const { t } = useTranslation(["common", "auth"])
+  const justLoggedOut = useRef(false)
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null)
+
+  useEffect(() => {
+    if (!authenticated && user === null) {
+      justLoggedOut.current = true
+      
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current)
+      }
+      
+      timeoutRef.current = setTimeout(() => {
+        justLoggedOut.current = false
+      }, 2000)
+    }
+  }, [authenticated, user])
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current)
+      }
+    }
+  }, [])
+
+  const handleSignInClick = () => {
+    if (!justLoggedOut.current) {
+      dispatch(authStepChanged("start"))
+    }
+  }
+
   return (
     <>
       {authenticated ? (
@@ -163,7 +195,7 @@ const AccountLinks = ({ authenticated, user, signOut }: PageFooterProps) => {
         </>
       ) : (
         <StyledInternalLink
-          handleClick={() => dispatch(authStepChanged("start"))}
+          handleClick={handleSignInClick}
         >
           {t("signIn", { ns: "auth" })}
         </StyledInternalLink>

--- a/components/auth/AuthModal.tsx
+++ b/components/auth/AuthModal.tsx
@@ -5,15 +5,38 @@ import StartModal from "./StartModal"
 import ForgotPasswordModal from "./ForgotPasswordModal"
 import VerifyEmailModal from "./VerifyEmailModal"
 import ProfileTypeModal from "./ProfileTypeModal"
-import { AuthFlowStep, authStepChanged, useAuth } from "./redux"
+import { AuthFlowStep, authStepChanged, useAuth, setProtectedPageAccess } from "./redux"
 import { useAppDispatch } from "components/hooks"
+import { useRouter } from "next/router"
+import { useEffect } from "react"
 
 export default function AuthModal() {
   const dispatch = useAppDispatch()
-  const { authFlowStep: currentModal } = useAuth()
+  const router = useRouter()
+  const { authFlowStep: currentModal, loading, isFromProtectedPage, protectedPageUrl, authenticated, user } = useAuth()
   const setCurrentModal = (step: AuthFlowStep) =>
     dispatch(authStepChanged(step))
-  const close = () => dispatch(authStepChanged(null))
+  
+  const close = () => {
+    dispatch(authStepChanged(null))
+    if (isFromProtectedPage) {
+      dispatch(setProtectedPageAccess({ isFromProtectedPage: false, url: undefined }))
+      router.push("/")
+    }
+  }
+
+  useEffect(() => {
+    if (isFromProtectedPage && authenticated && user && currentModal === null && !loading) {
+      if (protectedPageUrl) {
+        dispatch(setProtectedPageAccess({ isFromProtectedPage: false, url: undefined }))
+        router.push(protectedPageUrl)
+      }
+    }
+  }, [isFromProtectedPage, authenticated, user, currentModal, loading, protectedPageUrl, router, dispatch])
+
+  if (loading) {
+    return null
+  }
 
   return (
     <>
@@ -22,6 +45,7 @@ export default function AuthModal() {
         onHide={close}
         onSignInClick={() => setCurrentModal("signIn")}
         onSignUpClick={() => setCurrentModal("chooseProfileType")}
+        isFromProtectedPage={isFromProtectedPage}
       />
       <ProfileTypeModal
         show={currentModal === "chooseProfileType"}

--- a/components/auth/ProtectedPageWrapper.tsx
+++ b/components/auth/ProtectedPageWrapper.tsx
@@ -1,0 +1,42 @@
+import { useAuth } from "./redux"
+import { useAppDispatch } from "components/hooks"
+import { setProtectedPageAccess, authStepChanged } from "./redux"
+import { useRouter } from "next/router"
+import { useEffect } from "react"
+
+interface ProtectedPageWrapperProps {
+  children: React.ReactNode
+}
+
+export default function ProtectedPageWrapper({ children }: ProtectedPageWrapperProps) {
+  const dispatch = useAppDispatch()
+  const router = useRouter()
+  const { authenticated, loading, user } = useAuth()
+
+  useEffect(() => {
+    if (!loading) {
+      if (!authenticated && user === null) {
+        dispatch(setProtectedPageAccess({
+          isFromProtectedPage: true,
+          url: router.asPath
+        }))
+        dispatch(authStepChanged("start"))
+      } else if (authenticated && user) {
+        dispatch(setProtectedPageAccess({
+          isFromProtectedPage: false,
+          url: undefined
+        }))
+      }
+    }
+  }, [authenticated, loading, user, dispatch, router.asPath])
+
+  if (loading) {
+    return <div>Loading...</div>
+  }
+
+  if (!authenticated || !user) {
+    return null
+  }
+
+  return <>{children}</>
+} 

--- a/components/auth/StartModal.tsx
+++ b/components/auth/StartModal.tsx
@@ -6,10 +6,12 @@ export default function StartModal({
   show,
   onHide,
   onSignInClick,
-  onSignUpClick
+  onSignUpClick,
+  isFromProtectedPage = false
 }: Pick<ModalProps, "show" | "onHide"> & {
   onSignInClick: () => void
   onSignUpClick: () => void
+  isFromProtectedPage?: boolean
 }) {
   const { t } = useTranslation("auth")
 
@@ -17,7 +19,7 @@ export default function StartModal({
     <Modal show={show} onHide={onHide} aria-labelledby="start-modal" centered>
       <Modal.Header closeButton className={`py-4`}>
         <Modal.Title id="start-modal" className="visually-hidden">
-          {t("signUpOrIn")}
+          {isFromProtectedPage ? t("loginForProtectedAccess") : t("signUpOrIn")}
         </Modal.Title>
       </Modal.Header>
       <Modal.Body>
@@ -25,7 +27,17 @@ export default function StartModal({
           <Stack gap={3} direction="vertical" className="mb-4 text-center">
             <Image fluid src="/gov-with-mics.svg" alt="" />
 
-            <p className="h5">{t("addVoice")}</p>
+            <p className="h5">
+              {isFromProtectedPage 
+                ? t("loginForProtectedAccess") 
+                : t("addVoice")
+              }
+            </p>
+            {isFromProtectedPage && (
+              <p className="text-muted">
+                {t("loginRequiredForAccess")}
+              </p>
+            )}
           </Stack>
 
           <Stack gap={3}>

--- a/components/auth/redux.ts
+++ b/components/auth/redux.ts
@@ -22,18 +22,26 @@ export interface State {
   claims?: Claim
   /** True iff user is signed in */
   authenticated: boolean
+  loading: boolean
   authFlowStep: AuthFlowStep
+  isFromProtectedPage: boolean
+  protectedPageUrl?: string
+  justLoggedOut: boolean
 }
 
 const initialState: State = {
   authenticated: false,
   user: undefined,
-  authFlowStep: null
+  loading: true,
+  authFlowStep: null,
+  isFromProtectedPage: false,
+  protectedPageUrl: undefined,
+  justLoggedOut: false
 }
 
 export const {
   reducer,
-  actions: { authChanged, authStepChanged }
+  actions: { authChanged, authStepChanged, setProtectedPageAccess, setJustLoggedOut }
 } = createSlice({
   name: "auth",
   initialState,
@@ -45,9 +53,20 @@ export const {
       state.user = payload.user
       state.claims = payload.claims
       state.authenticated = Boolean(payload.user)
+      state.loading = false
     },
     authStepChanged(state, action: PayloadAction<AuthFlowStep>) {
       state.authFlowStep = action.payload
+    },
+    setProtectedPageAccess(
+      state,
+      action: PayloadAction<{ isFromProtectedPage: boolean; url?: string }>
+    ) {
+      state.isFromProtectedPage = action.payload.isFromProtectedPage
+      state.protectedPageUrl = action.payload.url
+    },
+    setJustLoggedOut(state, action: PayloadAction<boolean>) {
+      state.justLoggedOut = action.payload
     }
   }
 })

--- a/components/auth/service.tsx
+++ b/components/auth/service.tsx
@@ -76,13 +76,13 @@ export function requireAuth(
   Component: React.FC<React.PropsWithChildren<{ user: User }>>
 ) {
   return function ProtectedRoute() {
-    const { user } = useAuth()
+    const { user, loading } = useAuth()
     const router = useRouter()
     useEffect(() => {
-      if (user === null) {
+      if (!loading && user === null) {
         router.push({ pathname: "/" })
       }
-    }, [router, user])
+    }, [router, user, loading])
 
     return user ? <Component user={user} /> : null
   }

--- a/pages/edit-profile/[[...docName]].tsx
+++ b/pages/edit-profile/[[...docName]].tsx
@@ -1,12 +1,12 @@
 import { GetStaticPaths, GetStaticProps } from "next"
 import { useRouter } from "next/router"
 import { z } from "zod"
-import { requireAuth } from "../../components/auth"
 import { createPage } from "../../components/page"
 import EditProfile, {
   TabTitles
 } from "../../components/EditProfilePage/EditProfilePage"
 import { createGetStaticTranslationProps } from "components/translations"
+import ProtectedPageWrapper from "components/auth/ProtectedPageWrapper"
 
 const Query = z.object({
   docName: z.tuple([z.string()]).optional()
@@ -14,10 +14,14 @@ const Query = z.object({
 
 export default createPage({
   title: "Edit Profile",
-  Page: requireAuth(({ user }) => {
+  Page: () => {
     const tabTitle = Query.parse(useRouter().query).docName?.[0] || "about-you"
-    return <EditProfile tabTitle={tabTitle as TabTitles} />
-  })
+    return (
+      <ProtectedPageWrapper>
+        <EditProfile tabTitle={tabTitle as TabTitles} />
+      </ProtectedPageWrapper>
+    )
+  }
 })
 
 export const getStaticPaths: GetStaticPaths = async ctx => {

--- a/pages/newsfeed.tsx
+++ b/pages/newsfeed.tsx
@@ -1,10 +1,15 @@
 import { createPage } from "../components/page"
 import Newsfeed from "components/Newsfeed/Newsfeed"
+import ProtectedPageWrapper from "components/auth/ProtectedPageWrapper"
 
 export default createPage({
   title: "Newsfeed",
   Page: () => {
-    return <Newsfeed />
+    return (
+      <ProtectedPageWrapper>
+        <Newsfeed />
+      </ProtectedPageWrapper>
+    )
   }
 })
 

--- a/pages/submit-testimony.tsx
+++ b/pages/submit-testimony.tsx
@@ -1,4 +1,3 @@
-import { requireAuth } from "../components/auth"
 import { createPage } from "../components/page"
 import {
   usePublishService,
@@ -6,19 +5,20 @@ import {
 } from "../components/publish/hooks"
 import { SubmitTestimonyForm } from "../components/publish/SubmitTestimonyForm"
 import { createGetStaticTranslationProps } from "components/translations"
+import ProtectedPageWrapper from "components/auth/ProtectedPageWrapper"
 
 export default createPage({
   title: "Submit Testimony",
-  Page: requireAuth(() => {
+  Page: () => {
     useSyncRouterAndStore()
 
     return (
-      <>
+      <ProtectedPageWrapper>
         <usePublishService.Provider />
         <SubmitTestimonyForm />
-      </>
+      </ProtectedPageWrapper>
     )
-  })
+  }
 })
 
 export const getStaticProps = createGetStaticTranslationProps([

--- a/public/locales/en/auth.json
+++ b/public/locales/en/auth.json
@@ -54,7 +54,7 @@
   "subscribeNewsletter": "Click here to subscribe to our newsletter",
   "verifyEmail": "Verify your email address",
   "verifyLinkSent": "Please verify your email for your account by clicking the verification link we sent to your email. You will be required to verify your email before submitting testimony.",
-  "setUpProfile": "Set Up Your Profile"
-  
-
+  "setUpProfile": "Set Up Your Profile",
+  "loginForProtectedAccess": "Login Required",
+  "loginRequiredForAccess": "You need to be logged in to access this page."
 }


### PR DESCRIPTION
# Summary

This PR extends and improves the protected page authentication modal logic originally implemented for the newsfeed page (see #1841). Now, all protected pages (newsfeed, edit profile, submit testimony) use a unified modal-based authentication flow. The user experience is more consistent and several known issues are fixed.

# Checklist

- [x] Fixed modal flash when refreshing the newsfeed page after login.
- [x] All protected pages use unified modal logic.
- [x] Modal text is now translatable (previously hardcoded).
- [x] Pages are responsive on mobile.
- [ ] No modal flash or auto-trigger after logout (Not fully resolved, see Known Issues)

# Screenshots

<img width="1352" height="757" alt="image" src="https://github.com/user-attachments/assets/6f3a85ff-b96c-4216-83a6-43ccae50f15c" />

<img width="1362" height="839" alt="image" src="https://github.com/user-attachments/assets/826220ac-200c-4459-ab17-be215eaa911b" />

# Known issues

- **Logout Modal Issue:**  
  After logging out from a protected page, the login modal may still auto-trigger immediately on the homepage. This is due to some logout flows not fully respecting the `justLoggedOut` flag or not using the `useLogoutWithDelay` hook everywhere.  
  - **Workaround:** Ensure all logout actions use `useLogoutWithDelay` instead of `signOutAndRedirectToHome` or direct `auth.signOut()`.
  - **Follow-up:** Further refactoring is needed to guarantee the modal never auto-triggers after logout in all scenarios.

# Steps to test

## To verify modal flash is fixed:
1. Log in and go to `/newsfeed`.
2. Refresh the page.
3. **Expected:** No login modal flash; content loads directly.

## To verify unified modal logic:
1. Log out.
2. Visit `/newsfeed`, `/edit-profile`, or `/submit-testimony`.
3. **Expected:** Login/signup modal appears; page content is hidden until login.

## To verify translation is working:
1. Log out.
2. Visit `/newsfeed`.
3. When the login modal appears, check that the title and content are using translation keys (e.g. "Login Required", "You need to be logged in to access this page.") and not hardcoded.
4. (If your site supports multiple languages) Switch to another language and confirm the modal text updates accordingly.

## To reproduce the known logout issue:
1. Log in and visit a protected page.
2. Log out (using any logout button).
3. **Expected:** Should redirect to homepage and **not** show modal immediately.
4. **Actual:** Sometimes the login modal still auto-triggers after logout.