### PR TITLE
fix Newsfeed subheading

### DIFF
--- a/components/Card/CardTitle.tsx
+++ b/components/Card/CardTitle.tsx
@@ -17,6 +17,7 @@ interface CardTitleProps {
   isUserMatch?: boolean
   type?: string
   userRole?: string
+  isNewsfeed?: string
 }
 
 export const CardTitle = (props: CardTitleProps) => {

--- a/components/Card/CardTitle.tsx
+++ b/components/Card/CardTitle.tsx
@@ -30,7 +30,8 @@ export const CardTitle = (props: CardTitleProps) => {
     isUserMatch,
     subheader,
     type,
-    userRole
+    userRole,
+    isNewsfeed
   } = props
 
   return (
@@ -45,14 +46,18 @@ export const CardTitle = (props: CardTitleProps) => {
           subheader={subheader}
           type={type}
         />
-        <CardTitleFollowing
-          billId={billId}
-          header={header}
-          subheader={subheader}
-          isBillMatch={isBillMatch}
-          isUserMatch={isUserMatch}
-          type={type}
-        />
+        {isNewsfeed ? (
+          <CardTitleFollowing
+            billId={billId}
+            header={header}
+            subheader={subheader}
+            isBillMatch={isBillMatch}
+            isUserMatch={isUserMatch}
+            type={type}
+          />
+        ) : (
+          <></>
+        )}
       </CardBootstrap.Body>
     </CardBootstrap.Body>
   )

--- a/components/Newsfeed/Newsfeed.tsx
+++ b/components/Newsfeed/Newsfeed.tsx
@@ -230,6 +230,7 @@ export default function Newsfeed() {
                             testimonyId={element.testimonyId}
                             type={element.type}
                             userRole={element.userRole}
+                            isNewsfeed={"enable newsfeed specific subheading"}
                           />
                         </div>
                       ))}

--- a/components/NewsfeedCard/NewsfeedCard.tsx
+++ b/components/NewsfeedCard/NewsfeedCard.tsx
@@ -25,6 +25,7 @@ export const NewsfeedCard = (props: {
   timestamp: Timestamp
   type: string
   userRole?: string
+  isNewsfeed?: string
 }) => {
   const date = props.timestamp.toDate()
   const formattedTimestamp = `${date.toLocaleDateString()}`
@@ -40,6 +41,7 @@ export const NewsfeedCard = (props: {
       timestamp={formattedTimestamp}
       type={props.type}
       userRole={props.userRole}
+      isNewsfeed={"enable newsfeed specific subheading"}
     />
   )
 


### PR DESCRIPTION
# Summary

<img width="1196" height="886" alt="youdonot" src="https://github.com/user-attachments/assets/818b17ce-a66b-4703-a47c-4bf64ec62a48" />

this subheading is showing up on all instances of MapleCard component

should only show up at Newsfeed specific instances of MapleCard

solution provided by @HuanFengYeh


# Checklist

- [n/a] On the frontend, I've made my strings translate-able.
- [n/a] If I've added shared components, I've added a storybook story.
- [n/a] I've made pages responsive and look good on mobile.

# Screenshots

Non-Newsfeed MapleCard:

<img width="330" height="261" alt="image" src="https://github.com/user-attachments/assets/df57be4b-ea9b-4a6e-b4c1-c5cd8b16591f" />

Newsfeed MapleCard: 

<img width="499" height="138" alt="image" src="https://github.com/user-attachments/assets/dfdf298a-3c4d-46b9-bae6-1b0ad839a92f" />

# Known issues

none atm

# Steps to test/reproduce

_For each feature or bug fix, create a step by step list for how a reviewer can test it out. E.g.:_

1. Go to a specific bill, make sure the subheading (message about following things) does not show up on the Bill Tracker
2. Go to the Newsfeed and make sure the subheading shows up properly

![rUj0TYe](https://github.com/user-attachments/assets/c04a2629-cf34-4614-827c-db4079ebcb1d)

