### PR TITLE
[DRAFT] move reference to newsletter signup url to `components/common.tsx`

### DIFF
--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -11,6 +11,7 @@ import CustomDropdown, {
   CustomDropdownProps
 } from "components/Footer/CustomFooterDropdown"
 import { FooterContainer } from "./FooterContainer"
+import { NEWSLETTER_SIGNUP_URL } from "components/common"
 
 export type PageFooterProps = {
   children?: any
@@ -282,7 +283,7 @@ const PageFooter = (props: PageFooterProps) => {
           {t("legal.disclaimer")}
           {" - "}
           <a
-            href="https://cdn.forms-content.sg-form.com/d049f1ab-b547-11ee-9605-72ceb6b6e337"
+            href={NEWSLETTER_SIGNUP_URL}
             style={{ color: "white" }}
             target="_blank"
             rel="noopener noreferrer"

--- a/components/HeroHeader/HeroHeader.js
+++ b/components/HeroHeader/HeroHeader.js
@@ -6,6 +6,7 @@ import ScrollTrackingItem from "../ScrollTrackEffect/ScrollTrackerItem"
 import styles from "./HeroHeader.module.css"
 import { useTranslation } from "next-i18next"
 import { capitalize } from "lodash"
+import { NEWSLETTER_SIGNUP_URL } from "components/common"
 
 const HeroHeader = ({ authenticated }) => {
   const { t } = useTranslation("common")
@@ -70,7 +71,7 @@ const HeroHeader = ({ authenticated }) => {
                   </p>
                   <p>
                     <a
-                      href="https://cdn.forms-content.sg-form.com/d049f1ab-b547-11ee-9605-72ceb6b6e337"
+                      href={NEWSLETTER_SIGNUP_URL}
                       style={{ color: "white" }}
                       target="_blank"
                       rel="noopener noreferrer"

--- a/components/auth/TermsOfServiceModal.tsx
+++ b/components/auth/TermsOfServiceModal.tsx
@@ -3,6 +3,7 @@ import { Button, Col, Modal, Row, Stack } from "../bootstrap"
 import { External } from "components/links"
 import { NavLink } from "../Navlink"
 import { useTranslation } from "next-i18next"
+import { NEWSLETTER_SIGNUP_URL } from "components/common"
 
 export default function TermsOfServiceModal({
   show,
@@ -80,7 +81,7 @@ export default function TermsOfServiceModal({
               </Row>
               <Row>
                 <NavLink
-                  href="https://cdn.forms-content.sg-form.com/d049f1ab-b547-11ee-9605-72ceb6b6e337"
+                  href={NEWSLETTER_SIGNUP_URL}
                   other={{
                     className: `text-center fs-5 mt-4 text-secondary`,
                     target: "_blank",

--- a/components/common.tsx
+++ b/components/common.tsx
@@ -1,0 +1,1 @@
+export const NEWSLETTER_SIGNUP_URL = "https://example.com/newsletter-signup" // Add the actual URL here


### PR DESCRIPTION
# Summary

The newsletter signup link in the website is broken.

<img width="748" height="342" alt="Screenshot 2025-08-05 at 7 53 01 PM" src="https://github.com/user-attachments/assets/275d8a64-4127-4e75-ad31-59304b1fe709" />


### Steps to reproduce

1. Go to [mapletestimony.org](https://mapletestimony.org)
2. Click on `[Click Here to Subscribe to Our Newsletter](https://cdn.forms-content.sg-form.com/d049f1ab-b547-11ee-9605-72ceb6b6e337)`.
3. 404!



# Checklist

- [n/a] On the frontend, I've made my strings translate-able.
- [n/a] If I've added shared components, I've added a storybook story.
- [n/a] I've made pages responsive and look good on mobile.

# Screenshots

_Add some screenshots highlighting your changes._

# Known issues

_If you've run against limitations or caveats, include them here. Include follow-up issues as well._

# Steps to test/reproduce

_For each feature or bug fix, create a step by step list for how a reviewer can test it out. E.g.:_

1. Go to the home page
1. Click on a testimony
1. See that it's loaded with a loading spinner
