### PR TITLE
pin `chromadb` to v0.5.4 in `llm/requirements.txt`

### DIFF
--- a/llm/requirements.txt
+++ b/llm/requirements.txt
@@ -1,5 +1,5 @@
 Flask==3.1.0
-chromadb==0.5.0
+chromadb==0.5.4
 firebase-admin==6.7.0
 firebase-functions==0.4.2
 langchain-community==0.2.1


### PR DESCRIPTION
# Summary

Fixes an install error on M-Series MacOS machines by upgrading `chromadb` from `0.5.0` to `0.5.4`

Since it's a patch version update, there should be no compatibility issues. This patch version comes with a pre-built [wheel](https://realpython.com/python-wheels/#what-is-a-python-wheel) for MacOS ARM architectures to prevent install headaches such as the one I ran into.

Here's the [ChatGPT thread](https://chatgpt.com/s/t_689f304572808191aaa1930d202b25c8) I used to figure out the fix.

# Steps to test/reproduce

#### To reproduce the error:

1. On a machine running MacOS on an M-series chip, run `pip install --force-reinstall --no-cache-dir chromadb==0.5.0`. It will either fail to install/build `chroma-hnswlib` _or_  it will succeed but your install command output will read ` Building wheel for chroma-hnswlib`. 

#### To reproduce the fix

1. with `llm` as your working directory and this branch checked out, run `pip install --force-reinstall --no-cache-dir -r requirements.txt` and validate it installs. 

