### PR TITLE
activate hearing json usage

### DIFF
--- a/components/hearing/HearingDetails.tsx
+++ b/components/hearing/HearingDetails.tsx
@@ -75,7 +75,7 @@ export const HearingDetails = ({
   return (
     <Container className="mt-3 mb-3">
       <h1>
-        {t("hearing")} {hearingId}
+        {t("hearing", { ns: "hearing" })} {hearingId}
       </h1>
 
       <h5 className={`mb-3`}>{description}</h5>
@@ -134,7 +134,7 @@ export const HearingDetails = ({
             </VideoParent>
           ) : (
             <LegalContainer className={`fs-6 fw-bold my-3 py-2 rounded`}>
-              {t("no_video_on_file")}
+              {t("no_video_on_file", { ns: "hearing" })}
             </LegalContainer>
           )}
 

--- a/components/hearing/HearingSidebar.tsx
+++ b/components/hearing/HearingSidebar.tsx
@@ -109,13 +109,13 @@ export const HearingSidebar = ({
   return (
     <>
       <SidebarHeader className={`fs-6 fw-bold px-3 pb-2`}>
-        {t("hearing_details")}
+        {t("hearing_details", { ns: "hearing" })}
       </SidebarHeader>
 
       {dateCheck ? (
         <SidebarBody className={`border-bottom fs-6 fw-bold px-3 py-3`}>
           <SidebarSubbody className={`mb-1`}>
-            {t("recording_date")}
+            {t("recording_date", { ns: "hearing" })}
           </SidebarSubbody>
           <div className={`fw-normal`}>{formattedDate}</div>
         </SidebarBody>
@@ -127,14 +127,14 @@ export const HearingSidebar = ({
         <SidebarBody
           className={`border-bottom border-top fs-6 fw-bold px-3 py-3`}
         >
-          {t("committee_members")}
+          {t("committee_members", { ns: "hearing" })}
           <SidebarSubbody className={`mb-1 mt-2`}>
-            {t("chairs")}
+            {t("chairs", { ns: "hearing" })}
             <div>
               {houseChairperson && (
                 <LabeledIcon
                   idImage={`https://malegislature.gov/Legislators/Profile/170/${houseChairperson.MemberCode}.jpg`}
-                  mainText={`House Chair`}
+                  mainText={t("house_chair", { ns: "hearing" })}
                   subText={
                     <links.External
                       href={`https://malegislature.gov/Legislators/Profile/${houseChairperson.MemberCode}`}
@@ -149,7 +149,7 @@ export const HearingSidebar = ({
               {senateChairperson && (
                 <LabeledIcon
                   idImage={`https://malegislature.gov/Legislators/Profile/170/${senateChairperson.MemberCode}.jpg`}
-                  mainText={`Senate Chair`}
+                  mainText={t("senate_chair", { ns: "hearing" })}
                   subText={
                     <links.External
                       href={`https://malegislature.gov/Legislators/Profile/${senateChairperson.MemberCode}`}
@@ -168,13 +168,17 @@ export const HearingSidebar = ({
                     className={`btn btn-secondary d-flex text-nowrap mt-1 mx-1 p-1`}
                     onClick={toggleMembers}
                   >
-                    &nbsp; {showMembers ? "Show less" : "Show more"} &nbsp;
+                    &nbsp;{" "}
+                    {showMembers
+                      ? t("show_less", { ns: "hearing" })
+                      : t("show_more", { ns: "hearing" })}
+                    &nbsp;
                   </CommitteeButton>
                 </div>
 
                 {showMembers ? (
                   <>
-                    {t("members")}
+                    {t("members", { ns: "hearing" })}
                     <div>
                       {members.map((member: Members, index: number) => {
                         if (
@@ -185,7 +189,7 @@ export const HearingSidebar = ({
                             <LabeledIcon
                               key={index}
                               idImage={`https://malegislature.gov/Legislators/Profile/170/${member.id}.jpg`}
-                              mainText={`Member`}
+                              mainText={t("member", { ns: "hearing" })}
                               subText={
                                 <links.External
                                   href={`https://malegislature.gov/Legislators/Profile/${member.id}`}

--- a/components/hearing/Transcriptions.tsx
+++ b/components/hearing/Transcriptions.tsx
@@ -96,7 +96,7 @@ export const Transcriptions = ({
         </Container>
       ) : (
         <ErrorContainer className={`fs-6 fw-bold mb-2 py-2 rounded`}>
-          <div>{t("transcription_not_on_file")}</div>
+          <div>{t("transcription_not_on_file", { ns: "hearing" })}</div>
         </ErrorContainer>
       )}
     </>

--- a/public/locales/en/hearing.json
+++ b/public/locales/en/hearing.json
@@ -3,8 +3,13 @@
   "committee_members": "Committee members",
   "hearing": "Hearing ",
   "hearing_details": "Hearing details",
+  "house_chair": "House Chair",
+  "member": "Member",
   "members": "Members",
   "no_video_on_file": "This hearing does not yet have a video on file",
   "recording_date": "Recording date",
+  "senate_chair": "Senate Chair",
+  "show_less": "Show less",
+  "show_more": "Show more",
   "transcription_not_on_file": "This hearing does not yet have a transcription on file"
 }


### PR DESCRIPTION
# Summary

make it so that the Hearing component recognizes the translations in hearing.json

# Checklist

- [x] On the frontend, I've made my strings translate-able.
- [n/a] If I've added shared components, I've added a storybook story.
- [n/a] I've made pages responsive and look good on mobile.

# Screenshots

<img width="1321" height="666" alt="image" src="https://github.com/user-attachments/assets/1227ddf4-1cd6-4c86-9de9-f0f368a210a3" />

# Known issues

none at this time

# Steps to test/reproduce

1. Go to the /hearing/5100
