### PR TITLE
Use pip directly

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -14,7 +14,7 @@
     },
     {
       "predeploy": [
-        ". llm/venv/bin/activate && python3 -m pip install -r llm/requirements.txt"
+        ". llm/venv/bin/activate && pip install -r llm/requirements.txt"
       ],
       "source": "llm",
       "codebase": "maple-llm",

--- a/infra/firebase.compose.json
+++ b/infra/firebase.compose.json
@@ -13,7 +13,7 @@
     },
     {
       "predeploy": [
-        ". llm/venv/bin/activate && python3 -m pip install -r llm/requirements.txt"
+        ". llm/venv/bin/activate && pip install -r llm/requirements.txt"
       ],
       "source": "llm",
       "codebase": "maple-llm",


### PR DESCRIPTION
# Summary

<img width="693" height="88" alt="image" src="https://github.com/user-attachments/assets/5c95942a-8668-41e5-a4b0-b8f7120a1217" />

Suggests that we can't use `python3 -m pip`. Activating the environment first should give us `pip` from the `venv`.

# Checklist

- [ ] On the frontend, I've made my strings translate-able.
- [ ] If I've added shared components, I've added a storybook story.
- [ ] I've made pages responsive and look good on mobile.

# Screenshots

_Add some screenshots highlighting your changes._

# Known issues

_If you've run against limitations or caveats, include them here. Include follow-up issues as well._

# Steps to test/reproduce

_For each feature or bug fix, create a step by step list for how a reviewer can test it out. E.g.:_

1. Go to the home page
1. Click on a testimony
1. See that it's loaded with a loading spinner
