### PR TITLE
Use the correct key for fetching `content`

### DIFF
--- a/llm/bill_on_document_created.py
+++ b/llm/bill_on_document_created.py
@@ -45,8 +45,8 @@ def run_trigger(event: Event[DocumentSnapshot | None]) -> None:
     # If the summary is already populated, only run the tags code
     summary = inserted_content.get("summary")
     if summary is None:
-        document_text = inserted_content.get("contents", {}).get("DocumentText")
-        document_title = inserted_content.get("contents", {}).get("Title")
+        document_text = inserted_content.get("content", {}).get("DocumentText")
+        document_title = inserted_content.get("content", {}).get("Title")
         if document_text is None or document_title is None:
             print(f"bill with id `{bill_id}` unable to fetch document text or title")
             return


### PR DESCRIPTION
# Summary

Found this mistake last week.

<img width="356" height="442" alt="image" src="https://github.com/user-attachments/assets/64b1fb9f-3097-46bc-b76d-63fc5be008f1" />

# Checklist

- [ ] On the frontend, I've made my strings translate-able.
- [ ] If I've added shared components, I've added a storybook story.
- [ ] I've made pages responsive and look good on mobile.

# Screenshots

_Add some screenshots highlighting your changes._

# Known issues

_If you've run against limitations or caveats, include them here. Include follow-up issues as well._

# Steps to test/reproduce

_For each feature or bug fix, create a step by step list for how a reviewer can test it out. E.g.:_

1. Go to the home page
1. Click on a testimony
1. See that it's loaded with a loading spinner
