### PR TITLE
Add summary backfill

### DIFF
--- a/llm/scripts/backfill_summaries.py
+++ b/llm/scripts/backfill_summaries.py
@@ -10,9 +10,28 @@ bills = bills_ref.get()
 count = 0
 for bill in bills:
     document = bill.to_dict()
-    if document.get("summary") is None or document.get("topics") is None:
-        # Notes: DocumentText _can_ be None
-        print(document.get("content", {}).get("DocumentText"))
-        print(document.get("content", {}).get("Title"))
-        print(document.get("content", {}).get("BillNumber"))
-        exit()
+    document_text = document.get("content", {}).get("DocumentText")
+    document_title = document.get("content", {}).get("Title")
+    summary = document.get("summary")
+
+    # No document text, skip it because we can't summarize it
+    if document_text is None:
+        print(f"{document['id']},skipped")
+        continue
+
+    # If the summary is already populated move on
+    if summary is not None:
+        print(f"{document['id']},previous_summary")
+        continue
+
+    # TODO: Generate the summary
+    print(f"{document['id']},generate_summary")
+
+    # If the summary is already populated move on
+    topics = document.get("topics")
+    if topics is not None:
+        print(f"{document['id']},previous_topics")
+        continue
+
+    # TODO: Populate the topics
+    print(f"{document['id']},generate_topics")

--- a/llm/scripts/backfill_summaries.py
+++ b/llm/scripts/backfill_summaries.py
@@ -1,0 +1,18 @@
+import firebase_admin
+from firebase_admin import firestore
+
+# Application Default credentials are automatically created.
+app = firebase_admin.initialize_app()
+db = firestore.client()
+
+bills_ref = db.collection("generalCourts/194/bills")
+bills = bills_ref.get()
+count = 0
+for bill in bills:
+    document = bill.to_dict()
+    if document.get("summary") is None or document.get("topics") is None:
+        # Notes: DocumentText _can_ be None
+        print(document.get("content", {}).get("DocumentText"))
+        print(document.get("content", {}).get("Title"))
+        print(document.get("content", {}).get("BillNumber"))
+        exit()


### PR DESCRIPTION
# Summary

**DO NOT MERGE**

Add a summary/topics backfill script. This is really intended as a one off script but could be useful if the document trigger didn't work properly.

# Checklist

- [ ] On the frontend, I've made my strings translate-able.
- [ ] If I've added shared components, I've added a storybook story.
- [ ] I've made pages responsive and look good on mobile.

# Screenshots

_Add some screenshots highlighting your changes._

# Known issues

_If you've run against limitations or caveats, include them here. Include follow-up issues as well._

# Steps to test/reproduce

_For each feature or bug fix, create a step by step list for how a reviewer can test it out. E.g.:_

1. Go to the home page
1. Click on a testimony
1. See that it's loaded with a loading spinner
