### PR TITLE
Use python3-pip and explicit python versions

### DIFF
--- a/.github/workflows/deploy-python-backend-dev.yml
+++ b/.github/workflows/deploy-python-backend-dev.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           sudo add-apt-repository ppa:deadsnakes/ppa -y
           sudo apt update
-          sudo apt install python3.11 python3.11-venv python3.11-pip
+          sudo apt install python3.11 python3.11-venv python-pip
       - name: Build and deploy to Firebase
         uses: w9jds/firebase-action@v13.18.0
         with:

--- a/firebase.json
+++ b/firebase.json
@@ -14,9 +14,9 @@
     },
     {
       "predeploy": [
-        "python3 -m venv llm/venv",
+        "python3.11 -m venv llm/venv",
         ". llm/venv/bin/activate",
-        "pip3 install -r llm/requirements.txt"
+        "python3.11 -m pip install -r llm/requirements.txt"
       ],
       "source": "llm",
       "codebase": "maple-llm",

--- a/infra/firebase.compose.json
+++ b/infra/firebase.compose.json
@@ -13,9 +13,9 @@
     },
     {
       "predeploy": [
-        "python3 -m venv llm/venv",
+        "python3.11 -m venv llm/venv",
         ". llm/venv/bin/activate",
-        "pip3 install -r llm/requirements.txt"
+        "python3.11 -m pip install -r llm/requirements.txt"
       ],
       "source": "llm",
       "codebase": "maple-llm",


### PR DESCRIPTION
# Summary

Recent error is that `python3.11-pip` doesn't exist. I found https://github.com/deadsnakes/issues/issues/117#issuecomment-2299476758 which mentions using `python3-pip` instead and then uses explicit explicit python versions and pip as a module.

# Checklist

- [ ] On the frontend, I've made my strings translate-able.
- [ ] If I've added shared components, I've added a storybook story.
- [ ] I've made pages responsive and look good on mobile.

# Screenshots

_Add some screenshots highlighting your changes._

# Known issues

_If you've run against limitations or caveats, include them here. Include follow-up issues as well._

# Steps to test/reproduce

_For each feature or bug fix, create a step by step list for how a reviewer can test it out. E.g.:_

1. Go to the home page
1. Click on a testimony
1. See that it's loaded with a loading spinner
