### PR TITLE
fix: redirect logged-out users when clicking Follow on testimony

### DIFF
--- a/components/shared/FollowButton.tsx
+++ b/components/shared/FollowButton.tsx
@@ -1,5 +1,6 @@
 import { StyledImage } from "components/ProfilePage/StyledProfileComponents"
 import { useTranslation } from "next-i18next"
+import { useRouter } from "next/router"
 import { useEffect, useContext } from "react"
 import { Button } from "react-bootstrap"
 import { useAuth } from "../auth"
@@ -19,6 +20,7 @@ export const BaseFollowButton = ({
   hide?: boolean
 }) => {
   const { t } = useTranslation(["profile"])
+  const router = useRouter()
 
   const { user } = useAuth()
   const uid = user?.uid
@@ -50,8 +52,14 @@ export const BaseFollowButton = ({
   const checkmark = isFollowing ? (
     <StyledImage src="/check-white.svg" alt="" />
   ) : null
-  const handleClick = (event: React.FormEvent<HTMLFormElement>) => {
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     event.preventDefault()
+
+    if (!uid) {
+      router.push(`/login?redirect=${encodeURIComponent(router.asPath)}`)
+      return
+    }
+
     isFollowing ? UnfollowClick() : FollowClick()
   }
 

--- a/components/testimony/TestimonyDetailPage/PolicyActions.tsx
+++ b/components/testimony/TestimonyDetailPage/PolicyActions.tsx
@@ -5,6 +5,7 @@ import { formUrl } from "components/publish"
 import { FC, ReactElement, useContext, useEffect } from "react"
 import { useCurrentTestimonyDetails } from "./testimonyDetailSlice"
 import { useTranslation } from "next-i18next"
+import { useRouter } from "next/router"
 import { useAuth } from "components/auth"
 import { TopicQuery } from "components/shared/FollowingQueries"
 import { StyledImage } from "components/ProfilePage/StyledProfileComponents"
@@ -39,6 +40,7 @@ export const PolicyActions: FC<React.PropsWithChildren<PolicyActionsProps>> = ({
 
   const { user } = useAuth()
   const uid = user?.uid
+  const router = useRouter()
 
   const { followStatus, setFollowStatus } = useContext(FollowContext)
 
@@ -69,6 +71,12 @@ export const PolicyActions: FC<React.PropsWithChildren<PolicyActionsProps>> = ({
   ) : null
   const handleClick = (event: React.MouseEvent<Element, MouseEvent>) => {
     event.preventDefault()
+
+    if (!uid) {
+      router.push(`/login?redirect=${encodeURIComponent(router.asPath)}`)
+      return
+    }
+
     isFollowing ? UnfollowClick() : FollowClick()
   }
 


### PR DESCRIPTION
## Bug
[Issue #2059](https://github.com/codeforboston/maple/issues/2059) reports that logged-out users can click the **Follow** button on a testimony page, but nothing happens.

## Fix
This PR updates `BaseFollowButton` to redirect unauthenticated users to the login page when they click follow/unfollow.

- uses `router.push('/login?redirect=...')` with the current path
- keeps the existing follow/unfollow behavior unchanged for authenticated users

This makes the button behavior consistent with the rest of the app’s auth-protected flows.

## Testing
- `YARN_IGNORE_ENGINES=1 yarn check-types`
- `YARN_IGNORE_ENGINES=1 ./node_modules/.bin/eslint components/shared/FollowButton.tsx`

Happy to address any feedback.

Greetings, saschabuehrle
