### PR TITLE
Send logged-out users to login when clicking Follow

### DIFF
--- a/components/shared/FollowButton.tsx
+++ b/components/shared/FollowButton.tsx
@@ -114,11 +114,10 @@ export const BaseFollowButton = ({
 
   const isFollowing = followStatus[topicName]
   const onClick = !uid
-    ? () =>
-        router.push(`/login?redirect=${encodeURIComponent(router.asPath)}`)
+    ? () => router.push(`/login?redirect=${encodeURIComponent(router.asPath)}`)
     : isFollowing
-      ? () => (confirmUnfollow ? setModalAction("unfollow") : UnfollowClick())
-      : () => (confirmFollow ? setModalAction("follow") : FollowClick())
+    ? () => (confirmUnfollow ? setModalAction("unfollow") : UnfollowClick())
+    : () => (confirmFollow ? setModalAction("follow") : FollowClick())
 
   return (
     <>

--- a/components/shared/FollowButton.tsx
+++ b/components/shared/FollowButton.tsx
@@ -1,4 +1,5 @@
 import { StyledImage } from "components/ProfilePage/StyledProfileComponents"
+import { useRouter } from "next/router"
 import { useTranslation } from "next-i18next"
 import { useEffect, useContext, useMemo, useState } from "react"
 import { Button } from "react-bootstrap"
@@ -88,6 +89,7 @@ export const BaseFollowButton = ({
 }) => {
   const { t } = useTranslation("common")
   const uid = useAuth().user?.uid
+  const router = useRouter()
   const { followStatus, setFollowStatus } = useContext(FollowContext)
   const [modalAction, setModalAction] = useState<"follow" | "unfollow" | null>(
     null
@@ -111,9 +113,12 @@ export const BaseFollowButton = ({
   }
 
   const isFollowing = followStatus[topicName]
-  const onClick = isFollowing
-    ? () => (confirmUnfollow ? setModalAction("unfollow") : UnfollowClick())
-    : () => (confirmFollow ? setModalAction("follow") : FollowClick())
+  const onClick = !uid
+    ? () =>
+        router.push(`/login?redirect=${encodeURIComponent(router.asPath)}`)
+    : isFollowing
+      ? () => (confirmUnfollow ? setModalAction("unfollow") : UnfollowClick())
+      : () => (confirmFollow ? setModalAction("follow") : FollowClick())
 
   return (
     <>


### PR DESCRIPTION
Closes #2059.

Clicking 'Follow H.54' (or any `FollowButton` variant) while logged out just looked broken: `setDoc` ran against `/users/undefined/activeTopicSubscriptions/...` and the security rules quietly rejected it, so the visitor saw nothing.

Pushed the same `/login?redirect=...` flow that `requireAuth` already uses, so the visitor signs in and lands back on the testimony (or bill / profile / ballot question) page they came from.