### PR TITLE
Fix vote modal

### DIFF
--- a/components/hearing/HearingSidebar.tsx
+++ b/components/hearing/HearingSidebar.tsx
@@ -9,7 +9,12 @@ import { firestore } from "../firebase"
 import * as links from "../links"
 import { billSiteURL, Internal } from "../links"
 import { LabeledIcon } from "../shared"
-import { Paragraph, TranscriptData, formatVTTTimestamp } from "./hearing"
+import {
+  CommitteeRecommendation,
+  CommitteeVoteRecord,
+  LegislativeMemberSummary,
+  TranscriptData
+} from "./hearing"
 
 type Bill = {
   BillNumber: string
@@ -365,9 +370,9 @@ function AgendaBill({
   const { t } = useTranslation(["common", "hearing"])
   const BillNumber = element.BillNumber
   const CourtNumber = element.GeneralCourtNumber
-  const [committeeRecommendations, setCommitteeRecommendations] = useState<any>(
-    []
-  )
+  const [committeeActions, setCommitteeActions] = useState<
+    CommitteeRecommendation[]
+  >([])
   const [settingsModal, setSettingsModal] = useState<"show" | null>(null)
 
   const close = () => setSettingsModal(null)
@@ -378,20 +383,35 @@ function AgendaBill({
     )
     const docData = bill.data()
 
-    setCommitteeRecommendations(docData?.content.CommitteeRecommendations)
+    // All recommendations for this bill
+    let committeeRecommendations: CommitteeRecommendation[] =
+      docData?.content.CommitteeRecommendations
+    for (const action of committeeRecommendations) {
+      action.Votes = action.Votes?.filter(
+        vote =>
+          vote.Vote &&
+          vote.Vote.length &&
+          vote.Vote.some(
+            vote =>
+              vote.Adverse?.length ||
+              vote.Favorable?.length ||
+              vote.NoVoteRecorded?.length ||
+              vote.ReserveRight?.length
+          )
+      )
+    }
+    // Recommendations for this bill from the relevant committee (regardless of whether they are in this hearing specifically)
+    committeeRecommendations = committeeRecommendations.filter(
+      action =>
+        action.Committee?.CommitteeCode === committeeCode &&
+        action.Votes?.length
+    )
+    setCommitteeActions(committeeRecommendations)
   }, [BillNumber, CourtNumber])
 
   useEffect(() => {
     BillNumber && CourtNumber ? hearingBill() : null
   }, [BillNumber, hearingBill, CourtNumber])
-
-  let committeeActions = []
-
-  committeeRecommendations
-    ? (committeeActions = committeeRecommendations.filter(
-        (action: any) => action.Committee.CommitteeCode === committeeCode
-      ))
-    : null
 
   return (
     <>
@@ -401,7 +421,7 @@ function AgendaBill({
             {BillNumber}
           </Internal>
           <SidebarSubbody className={`my-2`}>{element.Title}</SidebarSubbody>
-          {committeeActions[0]?.Votes[0]?.Question ? (
+          {committeeActions.length > 0 ? (
             <SidebarSubbody className={`d-flex justify-content-end mb-2`}>
               <button
                 className={`bg-transparent border-0 d-flex text-nowrap text-secondary mt-1 mx-1 p-1`}
@@ -430,7 +450,7 @@ function AgendaBill({
 
 type Props = Pick<ModalProps, "show" | "onHide"> & {
   BillNumber: string
-  committeeActions: any
+  committeeActions: CommitteeRecommendation[]
   CourtNumber: number
   generalCourtNumber: string | null
   onSettingsModalClose: () => void
@@ -446,6 +466,20 @@ function VotesModal({
   show
 }: Props) {
   const { t } = useTranslation(["common", "editProfile", "hearing"])
+  const votes: CommitteeVoteRecord[][] = committeeActions.map(action =>
+    action.Votes!.map(votes =>
+      (votes.Vote ?? []).reduce((acc, vote) => {
+        for (const [key, values] of Object.entries(vote) as [
+          keyof CommitteeVoteRecord,
+          LegislativeMemberSummary[]
+        ][]) {
+          acc[key] ??= []
+          acc[key]!.push(...values)
+        }
+        return acc
+      }, {})
+    )
+  )
 
   return (
     <Modal show={show} onHide={onHide} aria-labelledby="votes-modal" centered>
@@ -464,15 +498,17 @@ function VotesModal({
       </Modal.Header>
       <Modal.Body className={`bg-white p-3`}>
         <div className={`fw-bold`}>
-          {committeeActions[0]?.Votes[0]?.Question}
+          {committeeActions?.[0]?.Votes?.[0]?.Question ??
+            committeeActions?.[0]?.Action ??
+            "No question"}
         </div>
         <ModalLine />
         <div className={`fw-bold`}>
-          {t("yes", { ns: "hearing" })} (
-          {committeeActions[0]?.Votes[0]?.Vote[0]?.Favorable.length})
+          {t("yes", { ns: "hearing" })} ({votes[0]?.[0]?.Favorable?.length ?? 0}
+          )
         </div>
         {generalCourtNumber &&
-          committeeActions[0]?.Votes[0]?.Vote[0]?.Favorable.map(
+          (votes[0]?.[0]?.Favorable ?? []).map(
             (element: any, index: number) => (
               <Vote
                 key={index}
@@ -484,27 +520,24 @@ function VotesModal({
           )}
 
         <div className={`fw-bold`}>
-          {t("no", { ns: "hearing" })} (
-          {committeeActions[0]?.Votes[0]?.Vote[0]?.Adverse.length})
+          {t("no", { ns: "hearing" })} ({votes[0]?.[0]?.Adverse?.length ?? 0})
         </div>
         {generalCourtNumber &&
-          committeeActions[0]?.Votes[0]?.Vote[0]?.Adverse.map(
-            (element: any, index: number) => (
-              <Vote
-                key={index}
-                element={element}
-                generalCourtNumber={generalCourtNumber}
-                value={`no`}
-              />
-            )
-          )}
+          (votes[0]?.[0]?.Adverse ?? []).map((element: any, index: number) => (
+            <Vote
+              key={index}
+              element={element}
+              generalCourtNumber={generalCourtNumber}
+              value={`no`}
+            />
+          ))}
 
         <div className={`fw-bold`}>
           {t("no_vote", { ns: "hearing" })} (
-          {committeeActions[0]?.Votes[0]?.Vote[0]?.NoVoteRecorded.length})
+          {votes[0]?.[0]?.NoVoteRecorded?.length ?? 0})
         </div>
         {generalCourtNumber &&
-          committeeActions[0]?.Votes[0]?.Vote[0]?.NoVoteRecorded.map(
+          (votes[0]?.[0]?.NoVoteRecorded ?? []).map(
             (element: any, index: number) => (
               <Vote
                 key={index}
@@ -517,10 +550,10 @@ function VotesModal({
 
         <div className={`fw-bold`}>
           {t("reserve_right", { ns: "hearing" })} (
-          {committeeActions[0]?.Votes[0]?.Vote[0]?.ReserveRight.length})
+          {votes[0]?.[0]?.ReserveRight?.length ?? 0})
         </div>
         {generalCourtNumber &&
-          committeeActions[0]?.Votes[0]?.Vote[0]?.ReserveRight.map(
+          (votes[0]?.[0]?.ReserveRight ?? []).map(
             (element: any, index: number) => (
               <Vote
                 key={index}

--- a/components/hearing/HearingSidebar.tsx
+++ b/components/hearing/HearingSidebar.tsx
@@ -4,13 +4,14 @@ import Link from "next/link"
 import { useCallback, useEffect, useState } from "react"
 import type { ModalProps } from "react-bootstrap"
 import styled from "styled-components"
-import { Col, Image, Modal, Row } from "../bootstrap"
+import { Col, Image, Modal, Row, Dropdown } from "../bootstrap"
 import { firestore } from "../firebase"
 import * as links from "../links"
 import { billSiteURL, Internal } from "../links"
 import { LabeledIcon } from "../shared"
 import {
   CommitteeRecommendation,
+  CommitteeVote,
   CommitteeVoteRecord,
   LegislativeMemberSummary,
   TranscriptData
@@ -435,15 +436,17 @@ function AgendaBill({
           )}
         </div>
       </div>
-      <VotesModal
-        BillNumber={BillNumber}
-        committeeActions={committeeActions}
-        CourtNumber={CourtNumber}
-        generalCourtNumber={generalCourtNumber}
-        onHide={close}
-        onSettingsModalClose={() => setSettingsModal(null)}
-        show={settingsModal === "show"}
-      />
+      {committeeActions.length > 0 ? (
+        <VotesModal
+          BillNumber={BillNumber}
+          committeeActions={committeeActions}
+          CourtNumber={CourtNumber}
+          generalCourtNumber={generalCourtNumber}
+          onHide={close}
+          onSettingsModalClose={() => setSettingsModal(null)}
+          show={settingsModal === "show"}
+        />
+      ) : null}
     </>
   )
 }
@@ -466,9 +469,12 @@ function VotesModal({
   show
 }: Props) {
   const { t } = useTranslation(["common", "editProfile", "hearing"])
-  const votes: CommitteeVoteRecord[][] = committeeActions.map(action =>
-    action.Votes!.map(votes =>
-      (votes.Vote ?? []).reduce((acc, vote) => {
+  const votes: CommitteeVote[] = []
+  const [selectedVote, setSelectedVote] = useState(0)
+  for (const action of committeeActions) {
+    for (const vote of action.Votes!) {
+      // Merge different vote arrays into [0]
+      const record = vote.Vote!.reduce((acc, vote) => {
         for (const [key, values] of Object.entries(vote) as [
           keyof CommitteeVoteRecord,
           LegislativeMemberSummary[]
@@ -478,8 +484,10 @@ function VotesModal({
         }
         return acc
       }, {})
-    )
-  )
+      vote.Vote = [record]
+      votes.push(vote)
+    }
+  }
 
   return (
     <Modal show={show} onHide={onHide} aria-labelledby="votes-modal" centered>
@@ -497,18 +505,40 @@ function VotesModal({
         />
       </Modal.Header>
       <Modal.Body className={`bg-white p-3`}>
-        <div className={`fw-bold`}>
-          {committeeActions?.[0]?.Votes?.[0]?.Question ??
-            committeeActions?.[0]?.Action ??
-            "No question"}
+        <div className="fw-bold">
+          {votes.length > 1 ? (
+            <Dropdown>
+              <Dropdown.Toggle
+                variant="link"
+                className="p-0 text-start text-dark fw-bold text-decoration-none"
+                style={{ whiteSpace: "normal" }}
+              >
+                {votes[selectedVote].Question}
+              </Dropdown.Toggle>
+
+              <Dropdown.Menu className="w-100">
+                {votes.map((vote, n) => (
+                  <Dropdown.Item
+                    key={n}
+                    className="text-wrap"
+                    onClick={() => setSelectedVote(n)}
+                  >
+                    {vote.Question}
+                  </Dropdown.Item>
+                ))}
+              </Dropdown.Menu>
+            </Dropdown>
+          ) : (
+            votes[selectedVote].Question
+          )}
         </div>
         <ModalLine />
         <div className={`fw-bold`}>
-          {t("yes", { ns: "hearing" })} ({votes[0]?.[0]?.Favorable?.length ?? 0}
-          )
+          {t("yes", { ns: "hearing" })} (
+          {votes[selectedVote]?.Vote![0].Favorable?.length ?? 0})
         </div>
         {generalCourtNumber &&
-          (votes[0]?.[0]?.Favorable ?? []).map(
+          (votes[selectedVote]?.Vote![0].Favorable ?? []).map(
             (element: any, index: number) => (
               <Vote
                 key={index}
@@ -520,24 +550,27 @@ function VotesModal({
           )}
 
         <div className={`fw-bold`}>
-          {t("no", { ns: "hearing" })} ({votes[0]?.[0]?.Adverse?.length ?? 0})
+          {t("no", { ns: "hearing" })} (
+          {votes[selectedVote].Vote![0].Adverse?.length ?? 0})
         </div>
         {generalCourtNumber &&
-          (votes[0]?.[0]?.Adverse ?? []).map((element: any, index: number) => (
-            <Vote
-              key={index}
-              element={element}
-              generalCourtNumber={generalCourtNumber}
-              value={`no`}
-            />
-          ))}
+          (votes[selectedVote]?.Vote![0].Adverse ?? []).map(
+            (element: any, index: number) => (
+              <Vote
+                key={index}
+                element={element}
+                generalCourtNumber={generalCourtNumber}
+                value={`no`}
+              />
+            )
+          )}
 
         <div className={`fw-bold`}>
           {t("no_vote", { ns: "hearing" })} (
-          {votes[0]?.[0]?.NoVoteRecorded?.length ?? 0})
+          {votes[selectedVote]?.Vote![0].NoVoteRecorded?.length ?? 0})
         </div>
         {generalCourtNumber &&
-          (votes[0]?.[0]?.NoVoteRecorded ?? []).map(
+          (votes[selectedVote]?.Vote![0].NoVoteRecorded ?? []).map(
             (element: any, index: number) => (
               <Vote
                 key={index}
@@ -550,10 +583,10 @@ function VotesModal({
 
         <div className={`fw-bold`}>
           {t("reserve_right", { ns: "hearing" })} (
-          {votes[0]?.[0]?.ReserveRight?.length ?? 0})
+          {votes[selectedVote]?.Vote![0].ReserveRight?.length ?? 0})
         </div>
         {generalCourtNumber &&
-          (votes[0]?.[0]?.ReserveRight ?? []).map(
+          (votes[selectedVote]?.Vote![0].ReserveRight ?? []).map(
             (element: any, index: number) => (
               <Vote
                 key={index}

--- a/components/hearing/hearing.ts
+++ b/components/hearing/hearing.ts
@@ -170,3 +170,72 @@ export function toVTT(transcriptData: Paragraph[]): string {
 
   return vttLines.join("\n")
 }
+
+export interface CommitteeRecommendation {
+  Action?: string
+  FiscalAmounts?: FiscalAmount[]
+  Committee?: Committee
+  Votes?: CommitteeVote[]
+}
+
+export interface FiscalAmount {
+  FiscalType?: string
+  Amount?: string
+}
+
+export interface Committee {
+  CommitteeCode?: string
+  GeneralCourtNumber?: number
+  Details?: string
+}
+
+export interface CommitteeVote {
+  Question?: string
+  Bill?: CommitteeVoteBill
+  Committee?: Committee
+  Date: string
+  Vote?: CommitteeVoteRecord[]
+}
+
+export interface CommitteeVoteBill {
+  BillNumber?: string
+  DocketNumber?: string
+  Title?: string
+  PrimarySponsor?: BillSponsor
+  Cosponsors?: BillSponsor[]
+  JointSponsor?: BillSponsor
+  GeneralCourtNumber: number
+  Details?: string
+  IsDocketBookOnly: boolean
+}
+
+export interface BillSponsor {
+  Id?: string
+  Name?: string
+  /**
+   * Type of the Bill Sponsor:
+   * 1 = Legislative Member
+   * 2 = Committee
+   * 3 = Public Request
+   * 4 = Special Request
+   */
+  Type: 1 | 2 | 3 | 4
+  /**
+   * Only Committees and Legislative Members will have further details.
+   */
+  Details?: string
+  ResponseDate?: string
+}
+
+export interface CommitteeVoteRecord {
+  Favorable?: LegislativeMemberSummary[]
+  Adverse?: LegislativeMemberSummary[]
+  ReserveRight?: LegislativeMemberSummary[]
+  NoVoteRecorded?: LegislativeMemberSummary[]
+}
+
+export interface LegislativeMemberSummary {
+  GeneralCourtNumber: number
+  MemberCode?: string
+  Details?: string
+}


### PR DESCRIPTION
# Summary

Solves #2214. All committee votes are now shown in bills, and if there are multiple questions the user can switch between them.

# Checklist

- [x] I've made pages responsive and look good on mobile.

# Screenshots

<img width="1129" height="682" alt="Captura de pantalla_20260818_174314" src="https://github.com/user-attachments/assets/970516a7-de3e-4af7-82ee-3b9ed50d7caf" />

# Known issues

N/A

# Steps to test/reproduce

1. Check that the votes on a bill in the hearing page match with those present at https://malegislature.gov/Bills/194/xxx/CommitteeVote. However, this will not show votes by committees other than that in the hearing.
1. Check that a bill with multiple votes by this committee (if one exists) has a dropdown.
