### PR TITLE
Revert "Update Node to 22"

### DIFF
--- a/.github/actions/setup-repo/action.yml
+++ b/.github/actions/setup-repo/action.yml
@@ -4,7 +4,7 @@ inputs:
   node-version:
     description: "Version used by actions/setup-node"
     required: true
-    default: "22"
+    default: "20"
   yarn-version:
     description: "Version of Yarn used to install dependencies"
     required: true

--- a/firebase.json
+++ b/firebase.json
@@ -9,7 +9,7 @@
       "predeploy": ["yarn build:functions"],
       "source": "functions",
       "codebase": "maple",
-      "runtime": "nodejs22",
+      "runtime": "nodejs20",
       "runtimeConfig": ".runtimeconfig.json"
     },
     {

--- a/functions/.runtimeconfig.json
+++ b/functions/.runtimeconfig.json
@@ -1,6 +1,6 @@
 {
   "runtime": {
-    "nodejs22": {
+    "nodejs18": {
       "apt": {
         "packages": ["ffmpeg"]
       }

--- a/infra/Dockerfile.firebase
+++ b/infra/Dockerfile.firebase
@@ -1,4 +1,4 @@
-FROM andreysenov/firebase-tools:latest-node-22
+FROM andreysenov/firebase-tools:latest-node-20
 
 USER root
 RUN apt update && apt install -y curl python3 python3-pip python3-venv ffmpeg

--- a/infra/Dockerfile.node
+++ b/infra/Dockerfile.node
@@ -1,4 +1,4 @@
-FROM node:22-alpine
+FROM node:20-alpine
 
 USER root
 RUN apk update && apk add curl

--- a/infra/firebase.compose.json
+++ b/infra/firebase.compose.json
@@ -9,7 +9,7 @@
       "predeploy": ["yarn build:functions"],
       "source": "functions",
       "codebase": "maple",
-      "runtime": "nodejs22"
+      "runtime": "nodejs20"
     },
     {
       "predeploy": [

--- a/mcp-server/Dockerfile
+++ b/mcp-server/Dockerfile
@@ -1,5 +1,5 @@
 # ── Build stage ───────────────────────────────────────────────────────────────
-FROM node:22-slim AS builder
+FROM node:20-slim AS builder
 
 WORKDIR /app
 
@@ -11,7 +11,7 @@ COPY *.ts ./
 RUN npm run build
 
 # ── Runtime stage ─────────────────────────────────────────────────────────────
-FROM node:22-slim AS runtime
+FROM node:20-slim AS runtime
 
 WORKDIR /app
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "setRole": "ts-node -P tsconfig.script.json scripts/firebase-admin/setRole.ts"
   },
   "engines": {
-    "node": "^22",
+    "node": "^20",
     "yarn": "^1.22.19"
   },
   "browserslist": {
@@ -167,7 +167,7 @@
     "@types/luxon": "^2.0.9",
     "@types/marked": "^4.0.8",
     "@types/mustache": "^4.2.1",
-    "@types/node": "^22.0.0",
+    "@types/node": "^20.0.0",
     "@types/papaparse": "^5.3.5",
     "@types/react": "^18.2.43",
     "@types/react-copy-to-clipboard": "^5.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5014,10 +5014,10 @@
   dependencies:
     undici-types "~5.26.4"
 
-"@types/node@^22.0.0":
-  version "22.20.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.20.1.tgz#84e7cdf63cdaa20c134aa317ccc901aa21e16f0e"
-  integrity sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==
+"@types/node@^20.0.0":
+  version "20.19.41"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.19.41.tgz#bb266a1e0aaa2f4537d14ae8ebf238dd9ca73ce6"
+  integrity sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==
   dependencies:
     undici-types "~6.21.0"
 


### PR DESCRIPTION
Reverts codeforboston/maple#2224

The firebase deploy is broken now with this change - it looks like it's still trying to use node 20 to build. The fix here looks pretty easy, but there's a big PR we're going to try to deploy today so the plan is to revert this change for now and re-introduce it after that deploy goes through.