### PR TITLE
searchHealthCheck: 256MB, the nodejs22 bundle no longer loads in 128MB

### DIFF
--- a/functions/src/search/searchHealthCheck.ts
+++ b/functions/src/search/searchHealthCheck.ts
@@ -10,7 +10,7 @@ const connectionTimeoutSeconds = 5,
 export const searchHealthCheck = runWith({
   secrets: ["TYPESENSE_API_KEY"],
   timeoutSeconds: functionTimeoutSeconds,
-  memory: "128MB"
+  memory: "256MB"
 })
   .pubsub.schedule("every 30 minutes")
   .retryConfig({


### PR DESCRIPTION
# Summary

The node-22 deploy (#2231 rerun, attempt 2) landed 58/59 functions on nodejs22; the one failure was searchHealthCheck with "function load attempt timed out". It is the only function in the repo pinned to 128MB (everything else is 256MB+ or the 256MB gen1 default). Every gen1 function loads the whole functions bundle at startup - index.ts re-exports all codebases - and node 22's larger baseline footprint pushes that load past what a 128MB instance can do before the load timeout. Identical code loaded fine in the other 58 functions at 256MB.

The old nodejs20 version of searchHealthCheck is still serving in dev (failed updates keep the previous version), so the health check itself never stopped; this just lets the nodejs22 version actually come up.

Cost delta is noise: a 30s-timeout function running every 30 minutes.


_Add a short summary of the changes, and a reference to the original issue using `#` and the issue number, like #1_

# Checklist

- [ ] On the frontend, I've made my strings translate-able.
- [ ] If I've added shared components, I've added a storybook story.
- [ ] I've made pages responsive and look good on mobile.
- [ ] If I've added new Firestore queries, I've added any new required indexes to `firestore.indexes.json` (Please do not only create indexes through the Firebase Web UI, even though the error messages may reccommend it - indexes created this way may be obliterated by subsequent deploys)

# Screenshots

_Add some screenshots highlighting your changes._

# Known issues

_If you've run against limitations or caveats, include them here. Include follow-up issues as well._

# Steps to test/reproduce

_For each feature or bug fix, create a step by step list for how a reviewer can test it out. E.g.:_

1. Go to the home page
1. Click on a testimony
1. See that it's loaded with a loading spinner
