### PR TITLE
search: bound backfill chunk memory and force collection per page

### DIFF
--- a/functions/src/bills/search.ts
+++ b/functions/src/bills/search.ts
@@ -14,6 +14,10 @@ export const {
   alias: "bills",
   idField: "id",
   convertVersion: billNumberVariantsVersion,
+  /** Below the default: `body` carries the bill's full text, so a batch of
+   * this source is the largest the backfill handles anywhere. The per-chunk log
+   * line's peak-batch figure is what to read if this needs revisiting. */
+  batchSize: 100,
   schema: {
     /** Hyphens do not split tokens by default, so "vote-by-mail" indexes as one
      * token and the spaced form people type cannot reach it — the two spellings
@@ -55,11 +59,14 @@ export const {
     default_sorting_field: "testimonyCount"
   },
   convert: data => {
+    // Throw, don't return: the indexer's per-document catch counts and skips
+    // it. Log the id, not `data`, which is a whole bill body per failure.
     const validation = Bill.validateWithDefaults(data)
     if (!validation.success) {
-      console.error(data, validation.message, validation.details)
+      console.error(validation.message, validation.details)
+      throw Error(`Invalid bill ${data.court}-${data.id}`)
     }
-    const bill = Bill.checkWithDefaults(data)
+    const bill = validation.value
 
     const { categories, topics } = buildTopicsForSearch(bill.topics)
 

--- a/functions/src/search/SearchIndexer.test.ts
+++ b/functions/src/search/SearchIndexer.test.ts
@@ -7,6 +7,9 @@ jest.mock("../firebase", () => ({
   Timestamp: { now: () => ({}) }
 }))
 
+jest.mock("./forceGc", () => ({ forceGc: jest.fn() }))
+import { forceGc } from "./forceGc"
+
 const imports: any[][] = []
 jest.mock("./client", () => ({
   createClient: () => ({
@@ -25,24 +28,24 @@ jest.mock("./client", () => ({
   })
 }))
 
-/** A source that behaves like an ordered, cursor-paged Firestore query, keyed
- * by document path the way listPage's documentId() ordering is. `path`
+/** A source that behaves like an ordered, cursor-driven Firestore query, keyed
+ * by document path the way listBatch's documentId() ordering is. `path`
  * defaults to `id`; give docs distinct paths to model duplicated idField
  * values (the same bill number in several courts).
  */
 function fakeSource(docs: { id: string; body: string; path?: string }[]) {
   const pathOf = (d: { id: string; path?: string }) => d.path ?? d.id
-  const build = (startAfter: string | null, pageSize: number): any => ({
-    orderBy: () => build(startAfter, pageSize),
+  const build = (startAfter: string | null, limit: number): any => ({
+    orderBy: () => build(startAfter, limit),
     limit: (n: number) => build(startAfter, n),
-    startAfter: (cursor: { path: string }) => build(cursor.path, pageSize),
+    startAfter: (cursor: { path: string }) => build(cursor.path, limit),
     get: async () => {
       const rest =
         startAfter === null ? docs : docs.filter(d => pathOf(d) > startAfter)
-      const page = rest.slice(0, pageSize)
+      const batch = rest.slice(0, limit)
       return {
-        size: page.length,
-        docs: page.map(d => ({
+        size: batch.length,
+        docs: batch.map(d => ({
           exists: true,
           id: pathOf(d),
           ref: { path: pathOf(d) },
@@ -57,31 +60,36 @@ function fakeSource(docs: { id: string; body: string; path?: string }[]) {
 
 const pad = (n: number) => String(n).padStart(6, "0")
 
-const makeIndexer = (docs: { id: string; body: string }[]) =>
+const makeIndexer = (
+  docs: { id: string; body: string }[],
+  batchSize?: number
+) =>
   new SearchIndexer({
     alias: "widgets",
     schema: { fields: [{ name: "body", type: "string" }] },
     sourceCollection: fakeSource(docs) as any,
     documentTrigger: "widgets/{id}",
     idField: "id",
-    convert: (data: any) => ({ id: data.id, body: data.body })
+    convert: (data: any) => ({ id: data.id, body: data.body }),
+    batchSize
   } as CollectionConfig)
 
 beforeEach(() => {
   imports.length = 0
+  jest.mocked(forceGc).mockClear()
 })
 
-describe("importInSlices", () => {
+describe("importBatch", () => {
   const chunk = { startAfter: null, budgetMs: 60_000 }
 
-  it("imports a page that fits the byte budget in one call", async () => {
+  it("imports a batch that fits the byte budget in one call", async () => {
     const docs = [1, 2, 3].map(n => ({ id: pad(n), body: "x".repeat(1000) }))
     await makeIndexer(docs).backfillChunk(chunk)
     expect(imports).toHaveLength(1)
     expect(imports[0]).toHaveLength(3)
   })
 
-  it("splits a page on the byte boundary, not the document count", async () => {
+  it("splits a batch on the byte boundary, not the document count", async () => {
     // Three documents at 40% of the budget each: two fit, the third does not.
     const body = "x".repeat(Math.floor(IMPORT_BYTE_BUDGET * 0.4))
     const docs = [1, 2, 3].map(n => ({ id: pad(n), body }))
@@ -145,7 +153,7 @@ describe("backfillChunk", () => {
   it("resumes across a boundary that splits documents sharing an idField value", async () => {
     // Three source docs per idField value — a bill number appearing in three
     // general courts — with distinct paths. 250 is not a multiple of 3, so the
-    // page boundary lands inside a group; a value cursor on idField would skip
+    // batch boundary lands inside a group; a value cursor on idField would skip
     // the rest of that group on resume, where the path cursor does not.
     const grouped = Array.from({ length: 600 }, (_, n) => ({
       id: `H${pad(Math.floor(n / 3))}`,
@@ -163,6 +171,61 @@ describe("backfillChunk", () => {
       budgetMs: 60_000
     })
     expect(first.documents + resumed.documents).toBe(600)
+  })
+
+  it("reads batches at the size its config asks for", async () => {
+    const result = await makeIndexer(docs, 50).backfillChunk({
+      startAfter: null,
+      maxBatches: 1,
+      budgetMs: 60_000
+    })
+    expect(result.documents).toBe(50)
+    expect(result.cursor).toBe(pad(49))
+  })
+
+  it("reports the serialized size of everything it imported", async () => {
+    const body = "x".repeat(1000)
+    const result = await makeIndexer(
+      [1, 2, 3].map(n => ({ id: pad(n), body }))
+    ).backfillChunk({ startAfter: null, budgetMs: 60_000 })
+
+    // Exactly the JSONL the stub was handed: each line plus its newline.
+    const expected = imports
+      .flat()
+      .reduce((sum, d) => sum + Buffer.byteLength(JSON.stringify(d)) + 1, 0)
+    expect(result.bytes).toBe(expected)
+  })
+
+  /** The chunk total spans every batch, so it is the peak that says how much
+   * sits in memory at once — the number `batchSize` is chosen against. */
+  it("collects after every batch and reports resident memory", async () => {
+    const result = await makeIndexer(docs).backfillChunk({
+      startAfter: null,
+      budgetMs: 60_000
+    })
+    expect(result.batches).toBe(3)
+    expect(forceGc).toHaveBeenCalledTimes(3)
+    expect(result.peakRssBytes).toBeGreaterThan(0)
+    expect(result.peakRssAfterGcBytes).toBeGreaterThan(0)
+  })
+
+  it("reports the largest single batch, not just the chunk total", async () => {
+    const small = "x".repeat(1000)
+    const large = "x".repeat(50_000)
+    // 250 to a batch: the first batch is all small, the second holds the large.
+    const mixed = Array.from({ length: 300 }, (_, n) => ({
+      id: pad(n),
+      body: n < 250 ? small : large
+    }))
+
+    const result = await makeIndexer(mixed).backfillChunk({
+      startAfter: null,
+      budgetMs: 60_000
+    })
+    expect(result.batches).toBe(2)
+    expect(result.peakBatchBytes).toBeLessThan(result.bytes)
+    // The 50-document tail batch dwarfs the 250-document head batch.
+    expect(result.peakBatchBytes).toBeGreaterThan(result.bytes / 2)
   })
 
   it("counts documents that fail to convert without aborting the chunk", async () => {

--- a/functions/src/search/SearchIndexer.ts
+++ b/functions/src/search/SearchIndexer.ts
@@ -12,16 +12,20 @@ import {
 import { BackfillConfig, upgradePath } from "./backfillRun"
 import { createClient } from "./client"
 import { searchCollectionName } from "./collectionName"
-import { CollectionConfig } from "./config"
+import { CollectionConfig, DEFAULT_BATCH_SIZE } from "./config"
+import { forceGc } from "./forceGc"
 import { Timestamp } from "../firebase"
 
-/** Ceiling on one `documents().import()` body, held far enough under the 10 MB
- * maximum payload of the AWS API Gateway HTTP API these collections sit behind
- * that headers and encoding cannot push a batch over it. A batch over the cap
- * is rejected outright and would fail the same way on every retry. Budgeting
- * the import by serialized bytes rather than by document count is what makes
- * that impossible: bills carry their full text in `body`, so a fixed count is
- * safe at the mean and unsafe in the tail.
+/** Ceiling on one `documents().import()` body — one slice, which is the unit
+ * `importBatch` ships and never the unit a budget counts: a batch is one whole
+ * read of the source, and a batch can flush several slices. Held far enough
+ * under the
+ * 10 MB maximum payload of the AWS API Gateway HTTP API these collections sit
+ * behind that headers and encoding cannot push a slice over it. A slice over
+ * the cap is rejected outright and would fail the same way on every retry.
+ * Budgeting the import by serialized bytes rather than by document count is
+ * what makes that impossible: bills carry their full text in `body`, so a
+ * fixed count is safe at the mean and unsafe in the tail.
  */
 export const IMPORT_BYTE_BUDGET = 6 * 1024 * 1024
 
@@ -29,9 +33,29 @@ export type BackfillChunkResult = {
   /** Document path the next chunk resumes `startAfter`, or null when the
    * source is spent. */
   cursor: string | null
+  /** Batches imported. A batch is one read of the source — `batchSize`
+   * documents, converted and imported together, and the whole of what this
+   * chunk holds in memory at once. It is the unit every budget counts:
+   * `maxBatches` here, `MAX_BATCHES_PER_CHUNK` and the run's `numBatches` in
+   * ./backfillRun.ts. */
   batches: number
   documents: number
   convertFailures: number
+  /** Serialized size of everything this chunk imported, across every batch. */
+  bytes: number
+  /** The largest single batch in this chunk. A batch is what sits in memory at
+   * once, so this — not the chunk total — is the number to read when choosing a
+   * config's `batchSize`. */
+  peakBatchBytes: number
+  /** Highest resident memory seen after importing a batch, before the forced
+   * collection. This is the figure the container kills on. */
+  peakRssBytes: number
+  /** Highest resident memory seen after a forced collection. Flat across
+   * batches means the collection reclaims what a batch allocates; climbing
+   * means something is retained between batches. All four figures are logged
+   * rather than persisted: the run's `Totals` are a checkpoint a replayed
+   * chunk must reproduce exactly. */
+  peakRssAfterGcBytes: number
 }
 
 /** The id of a failed import's `document`, which the server echoes back as the
@@ -47,9 +71,9 @@ const failedDocumentId = (document: unknown): string | undefined => {
 }
 
 export class SearchIndexer {
-  /** How many source documents to read per Firestore page. Independent of the
-   * import payload, which `importInSlices` sizes by bytes. */
-  private readonly batchSize = 250
+  /** How many source documents to read per batch. Independent of the import
+   * payload, which `importBatch` sizes by bytes. */
+  private readonly batchSize: number
   private readonly client = createClient()
   private readonly collectionName: string
 
@@ -57,6 +81,17 @@ export class SearchIndexer {
 
   constructor(private readonly config: CollectionConfig) {
     this.collectionName = searchCollectionName(config)
+    const batchSize = config.batchSize ?? DEFAULT_BATCH_SIZE
+    // Rejected loudly rather than passed to `limit()`: a zero or fractional
+    // batch size makes the first batch come back empty, which `listBatch`
+    // reports
+    // as a null cursor, which the run reads as "source exhausted" — so the
+    // alias would be swapped onto an empty collection and the live one dropped.
+    if (!Number.isInteger(batchSize) || batchSize < 1)
+      throw Error(
+        `Invalid batchSize ${batchSize} for search config ${config.alias}`
+      )
+    this.batchSize = batchSize
   }
 
   private passesFilter(data: DocumentData | undefined) {
@@ -174,59 +209,99 @@ export class SearchIndexer {
     maxBatches?: number
     budgetMs: number
   }): Promise<BackfillChunkResult> {
-    const { convert } = this.config
     const deadline = Date.now() + budgetMs
     let cursor: string | null = startAfter
     let batches = 0
     let documents = 0
     let convertFailures = 0
+    let bytes = 0
+    let peakBatchBytes = 0
+    let peakRssBytes = 0
+    let peakRssAfterGcBytes = 0
 
     while (maxBatches === undefined || batches < maxBatches) {
-      // Checked after the first page so a chunk always makes progress, however
+      // Checked after the first batch so a chunk always makes progress, however
       // little budget it inherited.
       if (batches > 0 && Date.now() >= deadline) break
 
-      const page = await this.listPage(cursor)
-      cursor = page.cursor
+      const batch = await this.listBatch(cursor)
+      cursor = batch.cursor
 
-      if (page.docs.length) {
+      if (batch.docs.length) {
         batches++
-        const docs = page.docs.reduce((acc, d) => {
-          try {
-            const data = d.data()
-            if (!this.passesFilter(data)) return acc
-            acc.push(convert(data))
-          } catch (error: any) {
-            convertFailures++
-            console.error(`Failed to convert document: ${error.message}`)
-          }
-          return acc
-        }, [] as any[])
+        const imported = await this.importBatch(batch.docs)
+        documents += imported.documents
+        convertFailures += imported.convertFailures
+        bytes += imported.bytes
+        peakBatchBytes = Math.max(peakBatchBytes, imported.bytes)
 
-        await this.importInSlices(docs)
-        documents += docs.length
+        // Reclaim the batch before fetching the next one — see ./forceGc.ts.
+        // Dropping the snapshots first is what makes that possible: `batch` is
+        // still a live local in this frame, so a collection while it holds them
+        // would reclaim only the PREVIOUS batch and leave this one resident,
+        // both raising the real footprint to two batches and putting a batch's
+        // worth of noise into the after-gc figure below.
+        peakRssBytes = Math.max(peakRssBytes, process.memoryUsage.rss())
+        batch.docs.length = 0
+        forceGc()
+        peakRssAfterGcBytes = Math.max(
+          peakRssAfterGcBytes,
+          process.memoryUsage.rss()
+        )
       }
 
       if (cursor === null) break
     }
 
-    return { cursor, batches, documents, convertFailures }
+    return {
+      cursor,
+      batches,
+      documents,
+      convertFailures,
+      bytes,
+      peakBatchBytes,
+      peakRssBytes,
+      peakRssAfterGcBytes
+    }
   }
 
-  private async importInSlices(docs: any[]) {
-    if (!docs.length) return
+  /** Converts and imports one batch of snapshots, splitting the import into
+   * request-sized slices. Each document is converted, serialized and dropped in
+   * the same iteration, so the converted batch never exists as a whole: what is
+   * live at once is the snapshots plus at most one slice of lines. */
+  private async importBatch(snapshots: QueryDocumentSnapshot[]) {
+    const { convert } = this.config
     const collection = await this.getCollection()
     let slice: string[] = []
+    let sliceBytes = 0
+    let documents = 0
+    let convertFailures = 0
     let bytes = 0
 
+    // Releases the line array before the round trip: the joined body is the
+    // copy that ships, and reassigning the captured `let` is what frees this one.
     const flush = async () => {
       if (!slice.length) return
-      await this.importDocuments(collection, slice)
+      const body = slice.join("\n")
+      bytes += sliceBytes
       slice = []
-      bytes = 0
+      sliceBytes = 0
+      await this.importDocuments(collection, body)
     }
 
-    for (const doc of docs) {
+    for (const snapshot of snapshots) {
+      let doc: any
+      try {
+        const data = snapshot.data()
+        if (!this.passesFilter(data)) continue
+        doc = convert(data)
+      } catch (error: any) {
+        convertFailures++
+        console.error(`Failed to convert document: ${error.message}`)
+        continue
+      }
+      documents++
+
       // Serialized once, here: the same line is measured against the budget
       // and shipped as the import body, rather than stringified a second time
       // inside the client. Bytes, not string length: the cap is on the encoded
@@ -234,25 +309,26 @@ export class SearchIndexer {
       // non-ASCII. +1 for the JSONL newline.
       const line = JSON.stringify(doc)
       const size = Buffer.byteLength(line) + 1
-      if (slice.length && bytes + size > IMPORT_BYTE_BUDGET) await flush()
+      if (slice.length && sliceBytes + size > IMPORT_BYTE_BUDGET) await flush()
       slice.push(line)
-      bytes += size
+      sliceBytes += size
     }
     await flush()
+    return { documents, convertFailures, bytes }
   }
 
   /** Imports pre-serialized JSONL lines. The client's string form returns the
    * raw per-line results WITHOUT throwing ImportError — only its array form
    * does — so failures are detected here, and must be: a silently rejected
-   * batch would otherwise count as progress. */
-  private async importDocuments(collection: Collection, lines: string[]) {
+   * slice would otherwise count as progress. */
+  private async importDocuments(collection: Collection, body: string) {
     const response = await collection
       .documents()
-      .import(lines.join("\n"), { action: "upsert" })
-    const failures = String(response)
+      .import(body, { action: "upsert" })
+    const results = String(response)
       .split("\n")
       .map(line => JSON.parse(line))
-      .filter(r => r.success === false)
+    const failures = results.filter(r => r.success === false)
     if (failures.length) {
       console.error(
         failures.map(r => ({
@@ -262,7 +338,7 @@ export class SearchIndexer {
         }))
       )
       throw Error(
-        `${failures.length} of ${lines.length} documents failed to import`
+        `${failures.length} of ${results.length} documents failed to import`
       )
     }
   }
@@ -289,8 +365,8 @@ export class SearchIndexer {
     }
   }
 
-  /** One ordered page of the source, with the cursor to resume after it — null
-   * once the source is exhausted, which a short page already tells us.
+  /** One ordered batch of the source, with the cursor to resume after it —
+   * null once the source is exhausted, which a short batch already tells us.
    *
    * Ordered by document name, with the last document's path as the cursor: the
    * one ordering Firestore always serves without an index, and the one value
@@ -298,10 +374,10 @@ export class SearchIndexer {
    * Ordering by `idField` instead would make the persisted value-cursor skip
    * documents — Firestore positions a value cursor after ALL documents equal
    * to it, and bills' collectionGroup holds the same bill number once per
-   * general court, adjacent in that ordering, so page boundaries would
+   * general court, adjacent in that ordering, so batch boundaries would
    * silently drop the rest of a boundary-straddling group from the index.
    */
-  private async listPage(startAfter: string | null): Promise<{
+  private async listBatch(startAfter: string | null): Promise<{
     docs: QueryDocumentSnapshot[]
     cursor: string | null
   }> {

--- a/functions/src/search/backfillRun.test.ts
+++ b/functions/src/search/backfillRun.test.ts
@@ -1,6 +1,8 @@
 import {
   aliasForUpgradeId,
+  chunkBatchBudget,
   chunkPath,
+  MAX_BATCHES_PER_CHUNK,
   MAX_CHUNKS,
   nextChunk,
   upgradePath
@@ -37,6 +39,19 @@ describe("nextChunk", () => {
       type: "failed",
       error: expect.stringContaining("not advancing")
     })
+  })
+})
+
+describe("chunkBatchBudget", () => {
+  const cap = MAX_BATCHES_PER_CHUNK
+  it.each`
+    numBatches   | batchesSoFar | expected | why
+    ${undefined} | ${10_000}    | ${cap}   | ${"a full run is capped however far it has got"}
+    ${cap * 4}   | ${0}         | ${cap}   | ${"a budget larger than one chunk is capped"}
+    ${cap + 3}   | ${cap}       | ${3}     | ${"only what is left of the budget is handed over"}
+    ${4}         | ${9}         | ${0}     | ${"a spent budget floors at zero, so nextChunk ends the run"}
+  `("$why", ({ numBatches, batchesSoFar, expected }) => {
+    expect(chunkBatchBudget({ numBatches, batchesSoFar })).toBe(expected)
   })
 })
 

--- a/functions/src/search/backfillRun.ts
+++ b/functions/src/search/backfillRun.ts
@@ -10,14 +10,28 @@ import { z } from "zod"
  * than adding its work to the run twice.
  */
 
-/** Wall-clock a single chunk spends paging before it hands off. The chunk
- * function gets the 540s v1 ceiling; the remainder is room to write progress
- * and create the successor after the budget runs out mid-page. */
+/** Wall-clock a single chunk spends reading batches before it hands off. The
+ * chunk function gets the 540s v1 ceiling; the remainder is room to write
+ * progress and create the successor after the budget runs out mid-batch. */
 export const CHUNK_BUDGET_MS = 300_000
 
-/** Loop guard. Nothing legitimate reaches this — bills is ~49k documents at 250
- * per batch, and one chunk covers hundreds of batches — so hitting it means the
- * cursor stopped advancing, and the run fails loudly instead of chaining. */
+/** Ceiling on the batches one invocation moves, independent of the time budget.
+ *
+ * Not a memory bound: chained events mostly land on the same warm instance, so
+ * a chunk boundary is usually the same heap, and it is the forced collection
+ * after each batch (see ./forceGc.ts) that reclaims what one allocates. What
+ * the cap bounds is the cost of losing a chunk. An instance the container
+ * kills is gone, its retry lands on a fresh one and resumes from the persisted
+ * cursor, and the cap keeps that unit of loss to a few minutes of work rather
+ * than the whole five-minute budget's worth.
+ */
+export const MAX_BATCHES_PER_CHUNK = 25
+
+/** Loop guard. Nothing legitimate reaches this — bills is ~49k documents at 100
+ * documents per batch, and `MAX_BATCHES_PER_CHUNK` puts that at roughly twenty
+ * chunks —
+ * so hitting it means the cursor stopped advancing, and the run fails loudly
+ * instead of chaining. */
 export const MAX_CHUNKS = 500
 
 /** `failurePolicy: true` retries the same event for up to seven days. Past this
@@ -56,9 +70,9 @@ export const NO_TOTALS: Totals = {
 }
 
 /** The only knob a scheduled upgrade takes: a whole-run batch budget that builds
- * a deliberately partial index and swaps the alias anyway. A batch is one source
- * page, so the document count it corresponds to is `numBatches * batchSize` —
- * see `SearchIndexer.batchSize`. */
+ * a deliberately partial index and swaps the alias anyway. A batch is one read
+ * of the source, so the document count it corresponds to is
+ * `numBatches * batchSize` — see `SearchIndexer.batchSize`. */
 export const BackfillConfig = z.object({
   numBatches: z.number().positive().optional()
 })
@@ -84,6 +98,19 @@ export const UpgradeRun = BackfillConfig.extend({
   chunks: z.number().int().positive()
 })
 export type UpgradeRun = z.infer<typeof UpgradeRun>
+
+/** How many batches the chunk about to run may move: `MAX_BATCHES_PER_CHUNK`,
+ * or whatever is left of the run's `numBatches` budget if that is less. Floored
+ * at zero so a spent budget hands its chunk no batches, which returns the
+ * cursor untouched and lets `nextChunk` end the run rather than chaining. Kept
+ * pure alongside `nextChunk`, for the reason given there. */
+export const chunkBatchBudget = ({
+  numBatches = Infinity,
+  batchesSoFar
+}: {
+  numBatches?: number
+  batchesSoFar: number
+}) => Math.min(Math.max(numBatches - batchesSoFar, 0), MAX_BATCHES_PER_CHUNK)
 
 export type NextChunk =
   | { type: "done" }

--- a/functions/src/search/config.ts
+++ b/functions/src/search/config.ts
@@ -2,6 +2,11 @@ import { Query } from "@google-cloud/firestore"
 import { CollectionCreateSchema } from "typesense/lib/Typesense/Collections"
 import { DocumentData } from "../firebase"
 
+/** Batch size for a collection whose config does not set one. Held at the
+ * historical value: the collections carrying no large free text are fine at
+ * this size, and only bills needed a smaller one. */
+export const DEFAULT_BATCH_SIZE = 250
+
 export type BaseRecord = { id: string }
 export type Schema = Omit<CollectionCreateSchema, "name">
 export type CollectionConfig<T extends BaseRecord = BaseRecord> = {
@@ -12,6 +17,14 @@ export type CollectionConfig<T extends BaseRecord = BaseRecord> = {
   readonly idField: string
   readonly convert: (data: DocumentData) => T
   readonly filter?: (data: DocumentData) => boolean
+  /** Source documents the BACKFILL reads per batch, defaulting to
+   * `DEFAULT_BATCH_SIZE`. Lower it for a collection whose records carry large
+   * free text: the batch is what sits in memory at once (see
+   * `MAX_BATCHES_PER_CHUNK` in ./backfillRun.ts for the rest of that story),
+   * and the per-chunk log line reports the largest batch it saw. Governs
+   * `SearchIndexer` only, not the export scripts. Outside the collection-name
+   * hash (see ./collectionName.ts), so it forces no reindex. */
+  readonly batchSize?: number
   /** Bump to force a reindex when the indexed output changed but `convert`'s
    * own source did not — the collection name hashes `convert.toString()`, which
    * covers none of the helpers, validators or defaults `convert` imports from

--- a/functions/src/search/createSearchIndexer.ts
+++ b/functions/src/search/createSearchIndexer.ts
@@ -1,9 +1,11 @@
 import { EventContext, runWith } from "firebase-functions"
 import { nanoid } from "nanoid"
+import { getHeapStatistics } from "v8"
 import { db, QueryDocumentSnapshot, Timestamp } from "../firebase"
 import {
   BackfillConfig,
   ChunkDoc,
+  chunkBatchBudget,
   chunkPath,
   CHUNK_BUDGET_MS,
   MAX_EVENT_AGE_MS,
@@ -38,10 +40,13 @@ export function createSearchIndexer<T extends BaseRecord = BaseRecord>(
      * cursor, imports upserts into a collection nothing is aliased to yet, and
      * writes totals relative to the baseline on its own document, so running it
      * more than once converges rather than double-counting.
+     *
+     * What bounds a chunk's footprint is `MAX_BATCHES_PER_CHUNK` and the
+     * config's `batchSize`, not the memory tier.
      */
     runBackfillChunk: runWith({
       timeoutSeconds: 540,
-      memory: "512MB",
+      memory: "1GB",
       secrets: ["TYPESENSE_API_KEY"],
       failurePolicy: true
     })
@@ -173,10 +178,10 @@ async function advanceBackfill(
   try {
     const result = await indexer.backfillChunk({
       startAfter: chunk.cursor,
-      maxBatches:
-        run.numBatches === undefined
-          ? undefined
-          : Math.max(run.numBatches - chunk.before.batches, 0),
+      maxBatches: chunkBatchBudget({
+        numBatches: run.numBatches,
+        batchesSoFar: chunk.before.batches
+      }),
       budgetMs: CHUNK_BUDGET_MS
     })
 
@@ -187,8 +192,21 @@ async function advanceBackfill(
       documents: chunk.before.documents + result.documents,
       convertFailures: chunk.before.convertFailures + result.convertFailures
     }
+    // Sizing figures, for reading against the function's memory tier. The heap
+    // limit is V8's own: above the tier, it is the container that kills first
+    // and the forced collection in backfillChunk is what keeps RSS down; below
+    // it, V8 collects on its own and the forced one is redundant.
+    const mb = (bytes: number) => `${(bytes / 1024 / 1024).toFixed(1)} MB`
     console.log(
-      `Chunk ${chunk.index} of ${alias}: ${result.batches} batches, ${result.documents} documents, cursor ${result.cursor}`
+      `Chunk ${chunk.index} of ${alias}: ${result.batches} batches, ${
+        result.documents
+      } documents, ${mb(result.bytes)} (peak batch ${mb(
+        result.peakBatchBytes
+      )}); rss peak ${mb(result.peakRssBytes)}, after gc ${mb(
+        result.peakRssAfterGcBytes
+      )}, heap limit ${mb(getHeapStatistics().heap_size_limit)}; cursor ${
+        result.cursor
+      }`
     )
 
     const progress = {

--- a/functions/src/search/forceGc.test.ts
+++ b/functions/src/search/forceGc.test.ts
@@ -1,0 +1,53 @@
+import { forceGc } from "./forceGc"
+
+/** The runtime trick — flipping `--expose-gc` after startup and reading `gc`
+ * out of a fresh context — is the whole module, so the test is that it works
+ * on the Node this runs under: it resolves to a real collector rather than
+ * falling back to the no-op, and it can be called repeatedly. */
+describe("forceGc", () => {
+  it("exposes a real collector at runtime", () => {
+    const warn = jest.spyOn(console, "warn").mockImplementation(() => {})
+    forceGc()
+    forceGc()
+    expect(warn).not.toHaveBeenCalled()
+    warn.mockRestore()
+  })
+
+  it("reclaims garbage", () => {
+    let junk: string[] | undefined = Array.from(
+      { length: 2000 },
+      (_, n) => "x".repeat(10_000) + n
+    )
+    forceGc()
+    const before = process.memoryUsage().heapUsed
+    junk = undefined
+    forceGc()
+    const after = process.memoryUsage().heapUsed
+    expect(junk).toBeUndefined()
+    expect(after).toBeLessThan(before)
+  })
+
+  /** The heap assertion above passes for a plain `gc()` too — it frees the
+   * heap and keeps the pages committed. The container kills on RESIDENT
+   * memory, so the collection has to hand the pages back as well, and only the
+   * last-resort flavor does. Asserted as a fraction of the growth rather than
+   * an absolute figure, since RSS carries whatever else the worker is holding;
+   * the real reclaim is ~98% of it, and a plain `gc()` reclaims none. */
+  it("returns the pages it reclaims to the OS", () => {
+    forceGc()
+    const base = process.memoryUsage().rss
+    let junk: string[] | undefined = Array.from(
+      { length: 20_000 },
+      (_, n) => "x".repeat(10_000) + n
+    )
+    const peak = process.memoryUsage().rss
+    junk = undefined
+    forceGc()
+    const after = process.memoryUsage().rss
+
+    expect(junk).toBeUndefined()
+    const growth = peak - base
+    expect(growth).toBeGreaterThan(4 * 1024 * 1024)
+    expect(peak - after).toBeGreaterThan(growth / 4)
+  })
+})

--- a/functions/src/search/forceGc.ts
+++ b/functions/src/search/forceGc.ts
@@ -1,0 +1,80 @@
+import * as v8 from "v8"
+import * as vm from "vm"
+
+/** The options V8's GC extension takes for the collection this module needs: a
+ * synchronous major collection run as a low-memory notification. The `flavor`
+ * is the load-bearing part — the default (`regular`) frees the heap but keeps
+ * the pages committed, so RSS does not move.
+ *
+ * Measured in this loop's shape — allocate a batch of large strings, drop it,
+ * collect, twelve times — on node 22 on macOS: RSS plateaus at 751 MB with no
+ * forced collection, 670 MB with a bare `gc()` and 582 MB with these options.
+ * `heapUsed` sits at ~3 MB at all three plateaus, which is why heap figures
+ * cannot tell them apart and the run reports `peakRssAfterGcBytes` instead.
+ *
+ * Read those as a direction, not a budget. They are macOS, where V8 discards
+ * pages with `MADV_FREE_REUSABLE`; the deploy sandbox is Linux, where
+ * `MADV_DONTNEED` decrements RSS immediately and should do at least as well —
+ * but nobody has measured the sandbox. What keeps a chunk under the ceiling is
+ * the memory tier and `batchSize`; this is margin on top of them, and
+ * `peakRssAfterGcBytes` tracking `peakRssBytes` on a real run would mean the
+ * margin is not there. */
+const LAST_RESORT = {
+  type: "major",
+  execution: "sync",
+  flavor: "last-resort"
+} as const
+
+/** Runs a full, memory-reducing garbage collection of this process, or does
+ * nothing if the runtime will not expose one.
+ *
+ * Why it exists: the backfill's garbage is bill text — large strings that
+ * live in old space and are only reclaimed by a full mark-sweep. V8 schedules
+ * those against its own heap limit, which it grows toward geometrically and
+ * which need not be below the container's limit, so a chunk can be killed by
+ * the container before V8 sees any reason to collect. And a collection alone
+ * is not enough: V8 keeps freed pages for reuse and returns them to the OS
+ * only when idle, which a warm gen1 instance, CPU-throttled between events,
+ * may never be. The kill is measured on resident memory, so both steps have to
+ * happen while the chunk still runs — hence `LAST_RESORT` above rather than a
+ * bare `gc()`.
+ *
+ * Exposing `gc` normally needs `--expose-gc` on the command line, which cannot
+ * be set for one function, so the flag is set at runtime and `gc` read out of a
+ * fresh context, which V8 populates from the flags in force at its creation.
+ * The flag is put back immediately: the captured reference keeps working, and
+ * no later context in this process silently gains a `gc` global. The function
+ * collects the whole isolate, not just that context. Resolved lazily so only
+ * the process that calls it flips the flag.
+ */
+export const forceGc = (): void => (resolved ??= resolve())()
+
+let resolved: (() => void) | undefined
+
+const resolve = (): (() => void) => {
+  try {
+    v8.setFlagsFromString("--expose-gc")
+    const gc = vm.runInNewContext("gc") as (options?: unknown) => void
+    v8.setFlagsFromString("--no-expose-gc")
+    if (typeof gc !== "function") throw Error("gc is not a function")
+    try {
+      // Probed once rather than guarded on every call — and the probe is
+      // itself the first collection, since resolution happens on the first
+      // call, which wanted one anyway. It catches a runtime that rejects the
+      // options form outright, but not one that takes the object and ignores
+      // it: V8's extension does not validate these keys, so a bogus `flavor`
+      // throws nothing on node 22. Neither case can produce a false negative,
+      // so the fallback is worth keeping at the price of one call.
+      gc(LAST_RESORT)
+      return () => gc(LAST_RESORT)
+    } catch (error: any) {
+      console.warn(
+        `Last-resort GC unavailable, falling back to a plain collection; the heap will be freed but RSS will not drop: ${error.message}`
+      )
+      return () => gc()
+    }
+  } catch (error: any) {
+    console.warn(`Forced GC unavailable, relying on V8's own: ${error.message}`)
+    return () => {}
+  }
+}

--- a/scripts/firebase-admin/exportSearchCorpus.ts
+++ b/scripts/firebase-admin/exportSearchCorpus.ts
@@ -43,7 +43,7 @@ export const script: Script = async ({ args }) => {
   // document-name tiebreak, where a value cursor positions after ALL documents
   // equal to it — and bill numbers repeat across courts in the bills
   // collection group, so a value cursor would silently drop the rest of a
-  // boundary-straddling group (the same hazard SearchIndexer.listPage
+  // boundary-straddling group (the same hazard SearchIndexer.listBatch
   // documents).
   let cursor: QueryDocumentSnapshot | undefined
   for (;;) {


### PR DESCRIPTION
# Summary

The bills backfill was killed by the container at 512MB. Bill bodies are large strings that only a full mark-sweep reclaims, V8 schedules those against its own heap limit rather than the container's, and freed pages are not returned to the OS until V8 goes idle, which a warm gen1 instance throttled between events may never do.

- Force a full, memory-reducing collection after each page. `--expose-gc` cannot be set for one function, so the flag is flipped at runtime and `gc` read out of a fresh vm context (forceGc.ts).
- Convert, serialize and drop each document in one iteration so the converted page never exists as a whole alongside the snapshots.
- Per-config `batchSize` (default 250); bills at 100.
- Cap a chunk at 25 batches so an OOM-killed chunk loses minutes, not the whole time budget. Not a memory bound: chained events mostly land on the same warm instance.
- Validate a bill once in convert, throw on failure so the indexer's per-document catch counts it, and log the id rather than the body.
- runBackfillChunk memory 512MB -> 1GB.
- Log per chunk: total and peak-page serialized bytes, peak RSS before and after the forced collection, and V8's heap limit, so a dev run says which limit V8 is actually working against.

# Checklist

- [ ] On the frontend, I've made my strings translate-able.
- [ ] If I've added shared components, I've added a storybook story.
- [ ] I've made pages responsive and look good on mobile.
- [ ] If I've added new Firestore queries, I've added any new required indexes to `firestore.indexes.json` (Please do not only create indexes through the Firebase Web UI, even though the error messages may reccommend it - indexes created this way may be obliterated by subsequent deploys)

# Screenshots

_Add some screenshots highlighting your changes._

# Known issues

_If you've run against limitations or caveats, include them here. Include follow-up issues as well._

# Steps to test/reproduce

_For each feature or bug fix, create a step by step list for how a reviewer can test it out. E.g.:_

1. Go to the home page
1. Click on a testimony
1. See that it's loaded with a loading spinner
